### PR TITLE
Modernize Go tooling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - exhaustruct
     - funlen
     - goconst
+    - gomodguard
     - lll
     - wsl
   settings:

--- a/docs.go
+++ b/docs.go
@@ -1,3 +1,3 @@
 package main
 
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+//go:generate go tool tfplugindocs

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cysp/terraform-provider-censusworkspace
 
-go 1.25.8
+go 1.26.3
 
 require (
 	github.com/go-faster/errors v0.7.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
@@ -58,6 +57,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.2 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
+	github.com/hashicorp/terraform-plugin-docs v0.25.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.2.1 // indirect
@@ -108,4 +108,9 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+tool (
+	github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+	github.com/ogen-go/ogen/cmd/ogen
 )

--- a/internal/census-management-go/ogen.go
+++ b/internal/census-management-go/ogen.go
@@ -1,3 +1,3 @@
 package censusmanagement
 
-//go:generate go run github.com/ogen-go/ogen/cmd/ogen -target . -package censusmanagement -clean openapi/openapi.yml
+//go:generate go tool ogen -target . -package censusmanagement -clean openapi/openapi.yml

--- a/internal/terraform-plugin-framework-reflection/attribute_types.go
+++ b/internal/terraform-plugin-framework-reflection/attribute_types.go
@@ -26,9 +26,7 @@ func attributeTypesOf(ctx context.Context, typ reflect.Type) map[string]attr.Typ
 
 	attrs := make(map[string]attr.Type)
 
-	for i := range typ.NumField() {
-		field := typ.Field(i)
-
+	for field := range typ.Fields() {
 		tag := field.Tag.Get("tfsdk")
 		if tag == "" {
 			continue

--- a/internal/terraform-plugin-framework-reflection/set_attribute_values.go
+++ b/internal/terraform-plugin-framework-reflection/set_attribute_values.go
@@ -28,9 +28,7 @@ func SetAttributeValues(ctx context.Context, value any, attributes map[string]at
 		attributeKeysRemaining[key] = struct{}{}
 	}
 
-	for i := range typ.NumField() {
-		field := typ.Field(i)
-
+	for field := range typ.Fields() {
 		if field.PkgPath != "" {
 			continue
 		}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,9 +1,0 @@
-//go:build tools
-
-package tools
-
-import (
-	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
-
-	_ "github.com/ogen-go/ogen/cmd/ogen"
-)


### PR DESCRIPTION
## Summary
- move generator pins to Go module tool directives and use go tool in go:generate
- update the module Go directive to 1.26.3
- adopt Go 1.26 struct field iteration in reflection helpers
- silence the deprecated gomodguard linter while keeping gomodguard_v2 covered by default: all

## Verification
- go generate ./...
- go test ./...
- golangci-lint config verify
- golangci-lint cache clean && golangci-lint run