### PR TITLE
feat(source): add warehouse writeback retention

### DIFF
--- a/docs/resources/big_query_source.md
+++ b/docs/resources/big_query_source.md
@@ -36,6 +36,7 @@ resource "censusworkspace_big_query_source" "test" {
 ### Optional
 
 - `sync_engine` (String) The sync engine type for this source. Can only be set during creation and cannot be modified after.
+- `warehouse_writeback_retention_in_days` (Number) Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.
 
 ### Read-Only
 

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -38,6 +38,7 @@ resource "censusworkspace_source" "test" {
 
 - `credentials` (String) Credentials that should be associated with this source (e.g. hostname, port)
 - `sync_engine` (String) The sync engine type for this source. Can only be set during creation and cannot be modified after.
+- `warehouse_writeback_retention_in_days` (Number) Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.
 
 ### Read-Only
 

--- a/internal/census-management-go/oas_client_gen.go
+++ b/internal/census-management-go/oas_client_gen.go
@@ -306,6 +306,15 @@ func (c *Client) CreateSource(ctx context.Context, request *CreateSourceBody) (*
 }
 
 func (c *Client) sendCreateSource(ctx context.Context, request *CreateSourceBody) (res *IdResponseStatusCode, err error) {
+	// Validate request before sending.
+	if err := func() error {
+		if err := request.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return res, errors.Wrap(err, "validate")
+	}
 
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [1]string
@@ -1157,6 +1166,15 @@ func (c *Client) UpdateSource(ctx context.Context, request *UpdateSourceBody, pa
 }
 
 func (c *Client) sendUpdateSource(ctx context.Context, request *UpdateSourceBody, params UpdateSourceParams) (res *SourceResponseStatusCode, err error) {
+	// Validate request before sending.
+	if err := func() error {
+		if err := request.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return res, errors.Wrap(err, "validate")
+	}
 
 	u := uri.Clone(c.requestURL(ctx))
 	var pathParts [2]string

--- a/internal/census-management-go/oas_json_gen.go
+++ b/internal/census-management-go/oas_json_gen.go
@@ -608,14 +608,21 @@ func (s *CreateSourceBodyConnection) encodeFields(e *jx.Encoder) {
 			e.Raw(s.Credentials)
 		}
 	}
+	{
+		if s.WarehouseWritebackRetentionInDays.Set {
+			e.FieldStart("warehouse_writeback_retention_in_days")
+			s.WarehouseWritebackRetentionInDays.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfCreateSourceBodyConnection = [5]string{
+var jsonFieldsNameOfCreateSourceBodyConnection = [6]string{
 	0: "type",
 	1: "sync_engine",
 	2: "name",
 	3: "label",
 	4: "credentials",
+	5: "warehouse_writeback_retention_in_days",
 }
 
 // Decode decodes CreateSourceBodyConnection from json.
@@ -679,6 +686,16 @@ func (s *CreateSourceBodyConnection) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"credentials\"")
+			}
+		case "warehouse_writeback_retention_in_days":
+			if err := func() error {
+				s.WarehouseWritebackRetentionInDays.Reset()
+				if err := s.WarehouseWritebackRetentionInDays.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"warehouse_writeback_retention_in_days\"")
 			}
 		default:
 			return d.Skip()
@@ -1397,6 +1414,41 @@ func (s *IdResponseData) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes int64 as json.
+func (o OptInt64) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Int64(int64(o.Value))
+}
+
+// Decode decodes int64 from json.
+func (o *OptInt64) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptInt64 to nil")
+	}
+	o.Set = true
+	v, err := d.Int64()
+	if err != nil {
+		return err
+	}
+	o.Value = int64(v)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptInt64) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptInt64) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes bool as json.
 func (o OptNilBool) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -1924,6 +1976,12 @@ func (s *SourceData) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.WarehouseWritebackRetentionInDays.Set {
+			e.FieldStart("warehouse_writeback_retention_in_days")
+			s.WarehouseWritebackRetentionInDays.Encode(e)
+		}
+	}
+	{
 		e.FieldStart("created_at")
 		json.EncodeDateTime(e, s.CreatedAt)
 	}
@@ -1941,16 +1999,17 @@ func (s *SourceData) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfSourceData = [9]string{
+var jsonFieldsNameOfSourceData = [10]string{
 	0: "id",
 	1: "name",
 	2: "type",
 	3: "sync_engine",
 	4: "label",
 	5: "connection_details",
-	6: "created_at",
-	7: "last_test_succeeded",
-	8: "last_tested_at",
+	6: "warehouse_writeback_retention_in_days",
+	7: "created_at",
+	8: "last_test_succeeded",
+	9: "last_tested_at",
 }
 
 // Decode decodes SourceData from json.
@@ -2029,8 +2088,18 @@ func (s *SourceData) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"connection_details\"")
 			}
+		case "warehouse_writeback_retention_in_days":
+			if err := func() error {
+				s.WarehouseWritebackRetentionInDays.Reset()
+				if err := s.WarehouseWritebackRetentionInDays.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"warehouse_writeback_retention_in_days\"")
+			}
 		case "created_at":
-			requiredBitSet[0] |= 1 << 6
+			requiredBitSet[0] |= 1 << 7
 			if err := func() error {
 				v, err := json.DecodeDateTime(d)
 				s.CreatedAt = v
@@ -2071,7 +2140,7 @@ func (s *SourceData) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [2]uint8{
-		0b01000111,
+		0b10000111,
 		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
@@ -2818,12 +2887,19 @@ func (s *UpdateSourceBodyConnection) encodeFields(e *jx.Encoder) {
 			e.Raw(s.Credentials)
 		}
 	}
+	{
+		if s.WarehouseWritebackRetentionInDays.Set {
+			e.FieldStart("warehouse_writeback_retention_in_days")
+			s.WarehouseWritebackRetentionInDays.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfUpdateSourceBodyConnection = [3]string{
+var jsonFieldsNameOfUpdateSourceBodyConnection = [4]string{
 	0: "name",
 	1: "label",
 	2: "credentials",
+	3: "warehouse_writeback_retention_in_days",
 }
 
 // Decode decodes UpdateSourceBodyConnection from json.
@@ -2864,6 +2940,16 @@ func (s *UpdateSourceBodyConnection) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"credentials\"")
+			}
+		case "warehouse_writeback_retention_in_days":
+			if err := func() error {
+				s.WarehouseWritebackRetentionInDays.Reset()
+				if err := s.WarehouseWritebackRetentionInDays.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"warehouse_writeback_retention_in_days\"")
 			}
 		default:
 			return d.Skip()

--- a/internal/census-management-go/oas_request_decoders_gen.go
+++ b/internal/census-management-go/oas_request_decoders_gen.go
@@ -229,6 +229,14 @@ func (s *Server) decodeCreateSourceRequest(r *http.Request) (
 			}
 			return req, rawBody, close, err
 		}
+		if err := func() error {
+			if err := request.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return req, rawBody, close, errors.Wrap(err, "validate")
+		}
 		return &request, rawBody, close, nil
 	default:
 		return req, rawBody, close, validate.InvalidContentType(ct)
@@ -441,6 +449,14 @@ func (s *Server) decodeUpdateSourceRequest(r *http.Request) (
 				Err:         err,
 			}
 			return req, rawBody, close, err
+		}
+		if err := func() error {
+			if err := request.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return req, rawBody, close, errors.Wrap(err, "validate")
 		}
 		return &request, rawBody, close, nil
 	default:

--- a/internal/census-management-go/oas_schemas_gen.go
+++ b/internal/census-management-go/oas_schemas_gen.go
@@ -238,6 +238,9 @@ type CreateSourceBodyConnection struct {
 	Label OptNilString `json:"label"`
 	// Credentials that should be associated with this source (e.g. hostname, port).
 	Credentials jx.Raw `json:"credentials"`
+	// Number of days to retain warehouse writeback data. When set, automatically enables sync logs for
+	// this source.
+	WarehouseWritebackRetentionInDays OptInt64 `json:"warehouse_writeback_retention_in_days"`
 }
 
 // GetType returns the value of Type.
@@ -265,6 +268,11 @@ func (s *CreateSourceBodyConnection) GetCredentials() jx.Raw {
 	return s.Credentials
 }
 
+// GetWarehouseWritebackRetentionInDays returns the value of WarehouseWritebackRetentionInDays.
+func (s *CreateSourceBodyConnection) GetWarehouseWritebackRetentionInDays() OptInt64 {
+	return s.WarehouseWritebackRetentionInDays
+}
+
 // SetType sets the value of Type.
 func (s *CreateSourceBodyConnection) SetType(val string) {
 	s.Type = val
@@ -288,6 +296,11 @@ func (s *CreateSourceBodyConnection) SetLabel(val OptNilString) {
 // SetCredentials sets the value of Credentials.
 func (s *CreateSourceBodyConnection) SetCredentials(val jx.Raw) {
 	s.Credentials = val
+}
+
+// SetWarehouseWritebackRetentionInDays sets the value of WarehouseWritebackRetentionInDays.
+func (s *CreateSourceBodyConnection) SetWarehouseWritebackRetentionInDays(val OptInt64) {
+	s.WarehouseWritebackRetentionInDays = val
 }
 
 // Ref: #/DatasetData
@@ -583,6 +596,52 @@ func (s *IdResponseStatusCode) SetStatusCode(val int) {
 // SetResponse sets the value of Response.
 func (s *IdResponseStatusCode) SetResponse(val IdResponse) {
 	s.Response = val
+}
+
+// NewOptInt64 returns new OptInt64 with value set to v.
+func NewOptInt64(v int64) OptInt64 {
+	return OptInt64{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptInt64 is optional int64.
+type OptInt64 struct {
+	Value int64
+	Set   bool
+}
+
+// IsSet returns true if OptInt64 was set.
+func (o OptInt64) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptInt64) Reset() {
+	var v int64
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptInt64) SetTo(v int64) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptInt64) Get() (v int64, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptInt64) Or(d int64) int64 {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
 }
 
 // NewOptNilBool returns new OptNilBool with value set to v.
@@ -1039,6 +1098,9 @@ type SourceData struct {
 	// Deprecated. Use name instead.
 	Label             OptNilString `json:"label"`
 	ConnectionDetails jx.Raw       `json:"connection_details"`
+	// Number of days to retain warehouse writeback data. When set, automatically enables sync logs for
+	// this source.
+	WarehouseWritebackRetentionInDays OptInt64 `json:"warehouse_writeback_retention_in_days"`
 	// The timestamp when the source was created.
 	CreatedAt time.Time `json:"created_at"`
 	// Indicates if the last connection test to this source was successful.
@@ -1075,6 +1137,11 @@ func (s *SourceData) GetLabel() OptNilString {
 // GetConnectionDetails returns the value of ConnectionDetails.
 func (s *SourceData) GetConnectionDetails() jx.Raw {
 	return s.ConnectionDetails
+}
+
+// GetWarehouseWritebackRetentionInDays returns the value of WarehouseWritebackRetentionInDays.
+func (s *SourceData) GetWarehouseWritebackRetentionInDays() OptInt64 {
+	return s.WarehouseWritebackRetentionInDays
 }
 
 // GetCreatedAt returns the value of CreatedAt.
@@ -1120,6 +1187,11 @@ func (s *SourceData) SetLabel(val OptNilString) {
 // SetConnectionDetails sets the value of ConnectionDetails.
 func (s *SourceData) SetConnectionDetails(val jx.Raw) {
 	s.ConnectionDetails = val
+}
+
+// SetWarehouseWritebackRetentionInDays sets the value of WarehouseWritebackRetentionInDays.
+func (s *SourceData) SetWarehouseWritebackRetentionInDays(val OptInt64) {
+	s.WarehouseWritebackRetentionInDays = val
 }
 
 // SetCreatedAt sets the value of CreatedAt.
@@ -1451,6 +1523,9 @@ type UpdateSourceBodyConnection struct {
 	Label OptNilString `json:"label"`
 	// Credentials that should be associated with this source (e.g. hostname, port).
 	Credentials jx.Raw `json:"credentials"`
+	// Number of days to retain warehouse writeback data. When set, automatically enables sync logs for
+	// this source.
+	WarehouseWritebackRetentionInDays OptInt64 `json:"warehouse_writeback_retention_in_days"`
 }
 
 // GetName returns the value of Name.
@@ -1468,6 +1543,11 @@ func (s *UpdateSourceBodyConnection) GetCredentials() jx.Raw {
 	return s.Credentials
 }
 
+// GetWarehouseWritebackRetentionInDays returns the value of WarehouseWritebackRetentionInDays.
+func (s *UpdateSourceBodyConnection) GetWarehouseWritebackRetentionInDays() OptInt64 {
+	return s.WarehouseWritebackRetentionInDays
+}
+
 // SetName sets the value of Name.
 func (s *UpdateSourceBodyConnection) SetName(val OptString) {
 	s.Name = val
@@ -1481,6 +1561,11 @@ func (s *UpdateSourceBodyConnection) SetLabel(val OptNilString) {
 // SetCredentials sets the value of Credentials.
 func (s *UpdateSourceBodyConnection) SetCredentials(val jx.Raw) {
 	s.Credentials = val
+}
+
+// SetWarehouseWritebackRetentionInDays sets the value of WarehouseWritebackRetentionInDays.
+func (s *UpdateSourceBodyConnection) SetWarehouseWritebackRetentionInDays(val OptInt64) {
+	s.WarehouseWritebackRetentionInDays = val
 }
 
 type WorkspaceApiKey struct {

--- a/internal/census-management-go/oas_validators_gen.go
+++ b/internal/census-management-go/oas_validators_gen.go
@@ -51,6 +51,69 @@ func (s CreateSQLDatasetBodyType) Validate() error {
 	}
 }
 
+func (s *CreateSourceBody) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Connection.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "connection",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *CreateSourceBodyConnection) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.WarehouseWritebackRetentionInDays.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           1,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "warehouse_writeback_retention_in_days",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s DatasetData) Validate() error {
 	switch s.Type {
 	case SQLDatasetDataDatasetData:
@@ -263,6 +326,46 @@ func (s SQLDatasetDataType) Validate() error {
 	}
 }
 
+func (s *SourceData) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.WarehouseWritebackRetentionInDays.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           1,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "warehouse_writeback_retention_in_days",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
 func (s *SourceResponse) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -277,6 +380,17 @@ func (s *SourceResponse) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "status",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Data.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "data",
 			Error: err,
 		})
 	}
@@ -360,6 +474,69 @@ func (s *StatusResponseStatusCode) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "Response",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *UpdateSourceBody) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.Connection.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "connection",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s *UpdateSourceBodyConnection) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if value, ok := s.WarehouseWritebackRetentionInDays.Get(); ok {
+			if err := func() error {
+				if err := (validate.Int{
+					MinSet:        true,
+					Min:           1,
+					MaxSet:        false,
+					Max:           0,
+					MinExclusive:  false,
+					MaxExclusive:  false,
+					MultipleOfSet: false,
+					MultipleOf:    0,
+					Pattern:       nil,
+				}).Validate(int64(value)); err != nil {
+					return errors.Wrap(err, "int")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "warehouse_writeback_retention_in_days",
 			Error: err,
 		})
 	}

--- a/internal/census-management-go/openapi/schemas/source/create.yml
+++ b/internal/census-management-go/openapi/schemas/source/create.yml
@@ -19,6 +19,11 @@ CreateSourceBody:
           nullable: true
         credentials:
           description: Credentials that should be associated with this source (e.g. hostname, port)
+        warehouse_writeback_retention_in_days:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.
       required:
         - type
   required:

--- a/internal/census-management-go/openapi/schemas/source/data.yml
+++ b/internal/census-management-go/openapi/schemas/source/data.yml
@@ -19,6 +19,11 @@ SourceData:
       description: Deprecated. Use name instead.
       nullable: true
     connection_details: {}
+    warehouse_writeback_retention_in_days:
+      type: integer
+      format: int64
+      minimum: 1
+      description: Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.
     created_at:
       type: string
       format: date-time

--- a/internal/census-management-go/openapi/schemas/source/update.yml
+++ b/internal/census-management-go/openapi/schemas/source/update.yml
@@ -13,5 +13,10 @@ UpdateSourceBody:
           nullable: true
         credentials:
           description: Credentials that should be associated with this source (e.g. hostname, port)
+        warehouse_writeback_retention_in_days:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.
   required:
     - connection

--- a/internal/census-management-go/testing/source.go
+++ b/internal/census-management-go/testing/source.go
@@ -20,6 +20,7 @@ func UpdateSourceWithCreateSourceBody(source *cm.SourceData, body cm.CreateSourc
 	source.Name = connection.Type
 	source.Type = connection.Type
 	source.SyncEngine.SetTo(connection.SyncEngine.Or("basic"))
+	source.WarehouseWritebackRetentionInDays = connection.WarehouseWritebackRetentionInDays
 
 	if name, nameOk := connection.Name.Get(); nameOk {
 		source.Name = name
@@ -45,6 +46,10 @@ func UpdateSourceWithUpdateSourceBody(source *cm.SourceData, body cm.UpdateSourc
 		source.Label.SetTo(label)
 	} else {
 		source.Label.SetToNull()
+	}
+
+	if warehouseWritebackRetentionInDays, warehouseWritebackRetentionInDaysOk := connection.WarehouseWritebackRetentionInDays.Get(); warehouseWritebackRetentionInDaysOk {
+		source.WarehouseWritebackRetentionInDays.SetTo(warehouseWritebackRetentionInDays)
 	}
 
 	if connection.Credentials != nil {

--- a/internal/provider/big_query_source_model_request.go
+++ b/internal/provider/big_query_source_model_request.go
@@ -27,6 +27,10 @@ func (m *BigQuerySourceModel) ToCreateSourceData(_ context.Context) (cm.CreateSo
 
 	body.Connection.Credentials = enc.Bytes()
 
+	if !m.WarehouseWritebackRetentionInDays.IsNull() && !m.WarehouseWritebackRetentionInDays.IsUnknown() {
+		body.Connection.WarehouseWritebackRetentionInDays.SetTo(m.WarehouseWritebackRetentionInDays.ValueInt64())
+	}
+
 	return body, nil
 }
 
@@ -39,6 +43,10 @@ func (m *BigQuerySourceModel) ToUpdateSourceData(_ context.Context) (cm.UpdateSo
 	m.Credentials.Value().Encode(&enc)
 
 	body.Connection.Credentials = enc.Bytes()
+
+	if !m.WarehouseWritebackRetentionInDays.IsNull() && !m.WarehouseWritebackRetentionInDays.IsUnknown() {
+		body.Connection.WarehouseWritebackRetentionInDays.SetTo(m.WarehouseWritebackRetentionInDays.ValueInt64())
+	}
 
 	return body, nil
 }

--- a/internal/provider/big_query_source_model_response.go
+++ b/internal/provider/big_query_source_model_response.go
@@ -29,6 +29,10 @@ func NewBigQuerySourceModelFromResponse(ctx context.Context, response cm.SourceD
 		model.SyncEngine = types.StringValue(syncEngine)
 	}
 
+	if warehouseWritebackRetentionInDays, warehouseWritebackRetentionInDaysOk := response.WarehouseWritebackRetentionInDays.Get(); warehouseWritebackRetentionInDaysOk {
+		model.WarehouseWritebackRetentionInDays = types.Int64Value(warehouseWritebackRetentionInDays)
+	}
+
 	if response.ConnectionDetails != nil {
 		path := path.AtName("connection_details")
 

--- a/internal/provider/big_query_source_resource_test.go
+++ b/internal/provider/big_query_source_resource_test.go
@@ -79,12 +79,14 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 						"project_id": config.StringVariable("project-id"),
 						"location":   config.StringVariable("US"),
 					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(7),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionCreate),
 						plancheck.ExpectUnknownValue("censusworkspace_big_query_source.test", tfjsonpath.New("id")),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
@@ -106,6 +108,7 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 						"project_id": config.StringVariable("project-id"),
 						"location":   config.StringVariable("US"),
 					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(7),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -113,6 +116,7 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionNoop),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
@@ -136,13 +140,35 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 							"client_email":   config.StringVariable("client-email"),
 						}),
 					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(7),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source (updated)")),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 						plancheck.ExpectUnknownValue("censusworkspace_big_query_source.test", tfjsonpath.New("connection_details")),
+					},
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"source_name": config.StringVariable("Test Source (updated)"),
+					"source_credentials": config.ObjectVariable(map[string]config.Variable{
+						"project_id": config.StringVariable("project-id"),
+						"location":   config.StringVariable("US"),
+					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(14),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(14)),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(14)),
 					},
 				},
 			},

--- a/internal/provider/source_base.go
+++ b/internal/provider/source_base.go
@@ -4,20 +4,24 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type sourceModelBase struct {
-	ID                types.String      `tfsdk:"id"`
-	Name              types.String      `tfsdk:"name"`
-	Label             types.String      `tfsdk:"label"`
-	SyncEngine        types.String      `tfsdk:"sync_engine"`
-	CreatedAt         timetypes.RFC3339 `tfsdk:"created_at"`
-	LastTestedAt      timetypes.RFC3339 `tfsdk:"last_tested_at"`
-	LastTestSucceeded types.Bool        `tfsdk:"last_test_succeeded"`
+	ID                                types.String      `tfsdk:"id"`
+	Name                              types.String      `tfsdk:"name"`
+	Label                             types.String      `tfsdk:"label"`
+	SyncEngine                        types.String      `tfsdk:"sync_engine"`
+	WarehouseWritebackRetentionInDays types.Int64       `tfsdk:"warehouse_writeback_retention_in_days"`
+	CreatedAt                         timetypes.RFC3339 `tfsdk:"created_at"`
+	LastTestedAt                      timetypes.RFC3339 `tfsdk:"last_tested_at"`
+	LastTestSucceeded                 types.Bool        `tfsdk:"last_test_succeeded"`
 }
 
 func sourceBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
@@ -45,6 +49,17 @@ func sourceBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Att
 				stringplanmodifier.UseStateForUnknown(),
 			},
 			MarkdownDescription: "The sync engine type for this source. Can only be set during creation and cannot be modified after.",
+		},
+		"warehouse_writeback_retention_in_days": schema.Int64Attribute{
+			Optional: true,
+			Computed: true,
+			Validators: []validator.Int64{
+				int64validator.AtLeast(1),
+			},
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+			MarkdownDescription: "Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.",
 		},
 		"created_at": schema.StringAttribute{
 			CustomType:          timetypes.RFC3339Type{},

--- a/internal/provider/source_model_request.go
+++ b/internal/provider/source_model_request.go
@@ -25,6 +25,10 @@ func (m *SourceModel) ToCreateSourceData(_ context.Context) (cm.CreateSourceBody
 		body.Connection.Credentials = []byte(*credentials)
 	}
 
+	if !m.WarehouseWritebackRetentionInDays.IsNull() && !m.WarehouseWritebackRetentionInDays.IsUnknown() {
+		body.Connection.WarehouseWritebackRetentionInDays.SetTo(m.WarehouseWritebackRetentionInDays.ValueInt64())
+	}
+
 	return body, nil
 }
 
@@ -35,6 +39,10 @@ func (m *SourceModel) ToUpdateSourceData(_ context.Context) (cm.UpdateSourceBody
 
 	if credentials := m.Credentials.ValueStringPointer(); credentials != nil {
 		body.Connection.Credentials = []byte(*credentials)
+	}
+
+	if !m.WarehouseWritebackRetentionInDays.IsNull() && !m.WarehouseWritebackRetentionInDays.IsUnknown() {
+		body.Connection.WarehouseWritebackRetentionInDays.SetTo(m.WarehouseWritebackRetentionInDays.ValueInt64())
 	}
 
 	return body, nil

--- a/internal/provider/source_model_response.go
+++ b/internal/provider/source_model_response.go
@@ -26,6 +26,10 @@ func NewSourceModelFromResponse(_ context.Context, response cm.SourceData) (Sour
 		model.SyncEngine = types.StringValue(syncEngine)
 	}
 
+	if warehouseWritebackRetentionInDays, warehouseWritebackRetentionInDaysOk := response.WarehouseWritebackRetentionInDays.Get(); warehouseWritebackRetentionInDaysOk {
+		model.WarehouseWritebackRetentionInDays = types.Int64Value(warehouseWritebackRetentionInDays)
+	}
+
 	if response.ConnectionDetails != nil {
 		model.ConnectionDetails = jsontypes.NewNormalizedValue(string(response.ConnectionDetails))
 	}

--- a/internal/provider/source_resource_test.go
+++ b/internal/provider/source_resource_test.go
@@ -83,12 +83,14 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 						"project_id": config.StringVariable("project-id"),
 						"location":   config.StringVariable("US"),
 					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(7),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("censusworkspace_source.test", plancheck.ResourceActionCreate),
 						plancheck.ExpectUnknownValue("censusworkspace_source.test", tfjsonpath.New("id")),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
+						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
@@ -111,6 +113,7 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 						"project_id": config.StringVariable("project-id"),
 						"location":   config.StringVariable("US"),
 					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(7),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -118,6 +121,7 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectResourceAction("censusworkspace_source.test", plancheck.ResourceActionNoop),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
+						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
@@ -134,13 +138,36 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 						"project_id": config.StringVariable("project-id"),
 						"location":   config.StringVariable("US"),
 					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(7),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("censusworkspace_source.test", plancheck.ResourceActionUpdate),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source (updated)")),
+						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 						plancheck.ExpectUnknownValue("censusworkspace_source.test", tfjsonpath.New("connection_details")),
+					},
+				},
+			},
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"source_type": config.StringVariable("big_query"),
+					"source_name": config.StringVariable("Test Source (updated)"),
+					"source_credentials": config.MapVariable(map[string]config.Variable{
+						"project_id": config.StringVariable("project-id"),
+						"location":   config.StringVariable("US"),
+					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(14),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_source.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(14)),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(14)),
 					},
 				},
 			},
@@ -152,6 +179,7 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 					"source_credentials": config.MapVariable(map[string]config.Variable{
 						"project_id": config.StringVariable("project-id"),
 					}),
+					"source_warehouse_writeback_retention_in_days": config.IntegerVariable(14),
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -330,6 +358,7 @@ func testProtocol6SourceResourceReadAcceptsExistingLabelState(
 	resourceState["name"] = tftypes.NewValue(tftypes.String, "Test Source")
 	resourceState["label"] = tftypes.NewValue(tftypes.String, "Legacy Label")
 	resourceState["sync_engine"] = tftypes.NewValue(tftypes.String, nil)
+	resourceState["warehouse_writeback_retention_in_days"] = tftypes.NewValue(tftypes.Number, nil)
 	resourceState["created_at"] = tftypes.NewValue(tftypes.String, nil)
 
 	currentState, err := tfprotov6.NewDynamicValue(sourceType, tftypes.NewValue(sourceType, resourceState))

--- a/internal/provider/testdata/TestAccBigQuerySourceResourceCreateUpdateDelete/main.tf
+++ b/internal/provider/testdata/TestAccBigQuerySourceResourceCreateUpdateDelete/main.tf
@@ -2,4 +2,6 @@ resource "censusworkspace_big_query_source" "test" {
   name = var.source_name
 
   credentials = var.source_credentials
+
+  warehouse_writeback_retention_in_days = var.source_warehouse_writeback_retention_in_days
 }

--- a/internal/provider/testdata/TestAccBigQuerySourceResourceCreateUpdateDelete/vars.tf
+++ b/internal/provider/testdata/TestAccBigQuerySourceResourceCreateUpdateDelete/vars.tf
@@ -5,3 +5,8 @@ variable "source_name" {
 
 variable "source_credentials" {
 }
+
+variable "source_warehouse_writeback_retention_in_days" {
+  type    = number
+  default = null
+}

--- a/internal/provider/testdata/TestAccSourceResourceCreateUpdateDelete/main.tf
+++ b/internal/provider/testdata/TestAccSourceResourceCreateUpdateDelete/main.tf
@@ -4,4 +4,6 @@ resource "censusworkspace_source" "test" {
   name = var.source_name
 
   credentials = jsonencode(var.source_credentials)
+
+  warehouse_writeback_retention_in_days = var.source_warehouse_writeback_retention_in_days
 }

--- a/internal/provider/testdata/TestAccSourceResourceCreateUpdateDelete/vars.tf
+++ b/internal/provider/testdata/TestAccSourceResourceCreateUpdateDelete/vars.tf
@@ -9,3 +9,8 @@ variable "source_name" {
 
 variable "source_credentials" {
 }
+
+variable "source_warehouse_writeback_retention_in_days" {
+  type    = number
+  default = null
+}


### PR DESCRIPTION
## Summary

- add `warehouse_writeback_retention_in_days` to source create, update, and read API models
- expose the setting on `censusworkspace_source` and `censusworkspace_big_query_source`
- keep retention changes as in-place updates instead of forcing source recreation
- regenerate provider docs and the Census management client

## Validation

- `go test ./internal/provider -run 'TestAcc(SourceResourceCreateUpdateDelete|BigQuerySourceResourceCreateUpdateDelete)$' -count=1`
- `go test ./...`
