### PR TITLE
feat(provider): add write-only credentials

### DIFF
--- a/docs/resources/big_query_destination.md
+++ b/docs/resources/big_query_destination.md
@@ -46,7 +46,8 @@ Required:
 
 Optional:
 
-- `service_account_key` (String, Sensitive) Service account key JSON used by Census to write to BigQuery.
+- `service_account_key` (String, Sensitive) Service account key JSON used by Census to write to BigQuery. Configure at most one of `service_account_key` or `service_account_key_wo`.
+- `service_account_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Service account key JSON used by Census to write to BigQuery. Configure at most one of `service_account_key` or `service_account_key_wo`.
 
 
 <a id="nestedatt--connection_details"></a>

--- a/docs/resources/big_query_source.md
+++ b/docs/resources/big_query_source.md
@@ -63,10 +63,14 @@ Required:
 
 - `client_email` (String) Client email from the service account key JSON.
 - `client_id` (String) Client ID from the service account key JSON.
-- `private_key` (String, Sensitive) Private key from the service account key JSON.
 - `private_key_id` (String) Private key ID from the service account key JSON.
 - `project_id` (String) Google Cloud project ID from the service account key JSON.
 - `type` (String) Service account key type. Must be `service_account`.
+
+Optional:
+
+- `private_key` (String, Sensitive) Private key from the service account key JSON. Configure exactly one of `private_key` or `private_key_wo` when `service_account_key` is configured.
+- `private_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Private key from the service account key JSON. Configure exactly one of `private_key` or `private_key_wo` when `service_account_key` is configured.
 
 
 

--- a/docs/resources/braze_destination.md
+++ b/docs/resources/braze_destination.md
@@ -30,12 +30,14 @@ description: |-
 
 Required:
 
-- `api_key` (String, Sensitive) Braze REST API key Census uses to update users.
 - `instance_url` (String) Braze REST API endpoint URL for the destination instance.
 
 Optional:
 
-- `client_key` (String, Sensitive) Braze Data Import Key used when syncing Cohorts.
+- `api_key` (String, Sensitive) Braze REST API key Census uses to update users. Configure exactly one of `api_key` or `api_key_wo`.
+- `api_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Braze REST API key Census uses to update users. Configure exactly one of `api_key` or `api_key_wo`.
+- `client_key` (String, Sensitive) Braze Data Import Key used when syncing Cohorts. Configure at most one of `client_key` or `client_key_wo`.
+- `client_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Braze Data Import Key used when syncing Cohorts. Configure at most one of `client_key` or `client_key_wo`.
 
 
 <a id="nestedatt--connection_details"></a>

--- a/docs/resources/custom_api_destination.md
+++ b/docs/resources/custom_api_destination.md
@@ -60,13 +60,11 @@ Optional:
 <a id="nestedatt--credentials--custom_headers"></a>
 ### Nested Schema for `credentials.custom_headers`
 
-Required:
-
-- `value` (String) HTTP header value sent to the Custom API webhook.
-
 Optional:
 
 - `is_secret` (Boolean) Whether Census should store this header value as a secret.
+- `value` (String) HTTP header value sent to the Custom API webhook. Configure exactly one of `value` or `value_wo` for each header.
+- `value_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) HTTP header value sent to the Custom API webhook. Configure exactly one of `value` or `value_wo` for each header.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/ogen-go/ogen v1.20.3
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/crypto v0.52.0
 )
 
 require (
@@ -93,7 +94,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/internal/provider/big_query_destination_credential_resolvers.go
+++ b/internal/provider/big_query_destination_credential_resolvers.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func bigQueryDestinationModelWithWriteOnlyCredentials(plan, config BigQueryDestinationModel) (BigQueryDestinationModel, writeOnlyCredentialValues, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	values := writeOnlyCredentialValues{}
+
+	model := plan
+	credentials := plan.Credentials.Value()
+	configCredentials := configuredObjectOrPlan(config.Credentials, plan.Credentials).Value()
+
+	credentials.ProjectID = configCredentials.ProjectID
+	credentials.Location = configCredentials.Location
+
+	serviceAccountKey, serviceAccountKeyDiags := resolveStringCredentialInput(stringCredentialInput{
+		Legacy:        configCredentials.ServiceAccountKey,
+		WriteOnly:     configCredentials.ServiceAccountKeyWO,
+		LegacyPath:    path.Root("credentials").AtName("service_account_key"),
+		WriteOnlyPath: path.Root("credentials").AtName("service_account_key_wo"),
+	})
+	diags.Append(serviceAccountKeyDiags...)
+	diags.Append(serviceAccountKey.AddValueTo(values)...)
+
+	if serviceAccountKey.UsedWriteOnly {
+		credentials.ServiceAccountKeyWO = types.StringNull()
+	}
+
+	credentials.ServiceAccountKey = serviceAccountKey.Value
+
+	model.Credentials = NewTypedObject(credentials)
+
+	return model, values, diags
+}
+
+func sanitizedBigQueryDestinationCredentials(model, plan, config BigQueryDestinationModel, connectionDetails BigQueryDestinationConnectionDetails) BigQueryDestinationModel {
+	credentials := plan.Credentials.Value()
+	configCredentials := config.Credentials.Value()
+
+	if !configCredentials.ServiceAccountKeyWO.IsNull() {
+		credentials.ServiceAccountKey = types.StringNull()
+		connectionDetails.ServiceAccountKey = types.StringNull()
+	}
+
+	credentials.ServiceAccountKeyWO = types.StringNull()
+	credentials.UpdateWithConnectionDetails(connectionDetails)
+
+	model.Credentials = NewTypedObject(credentials)
+	model.ConnectionDetails = NewTypedObject(connectionDetails)
+
+	return model
+}

--- a/internal/provider/big_query_destination_model.go
+++ b/internal/provider/big_query_destination_model.go
@@ -17,9 +17,10 @@ type BigQueryDestinationModel struct {
 
 //nolint:recvcheck
 type BigQueryDestinationCredentials struct {
-	ProjectID         types.String `tfsdk:"project_id"`
-	Location          types.String `tfsdk:"location"`
-	ServiceAccountKey types.String `tfsdk:"service_account_key"`
+	ProjectID           types.String `tfsdk:"project_id"`
+	Location            types.String `tfsdk:"location"`
+	ServiceAccountKey   types.String `tfsdk:"service_account_key"`
+	ServiceAccountKeyWO types.String `tfsdk:"service_account_key_wo"`
 }
 
 type BigQueryDestinationConnectionDetails struct {

--- a/internal/provider/big_query_destination_resource.go
+++ b/internal/provider/big_query_destination_resource.go
@@ -15,11 +15,13 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*bigQueryDestinationResource)(nil)
-	_ resource.ResourceWithConfigure   = (*bigQueryDestinationResource)(nil)
-	_ resource.ResourceWithIdentity    = (*bigQueryDestinationResource)(nil)
-	_ resource.ResourceWithImportState = (*bigQueryDestinationResource)(nil)
-	_ resource.ResourceWithMoveState   = (*bigQueryDestinationResource)(nil)
+	_ resource.Resource                   = (*bigQueryDestinationResource)(nil)
+	_ resource.ResourceWithConfigure      = (*bigQueryDestinationResource)(nil)
+	_ resource.ResourceWithIdentity       = (*bigQueryDestinationResource)(nil)
+	_ resource.ResourceWithImportState    = (*bigQueryDestinationResource)(nil)
+	_ resource.ResourceWithModifyPlan     = (*bigQueryDestinationResource)(nil)
+	_ resource.ResourceWithMoveState      = (*bigQueryDestinationResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*bigQueryDestinationResource)(nil)
 )
 
 //nolint:ireturn
@@ -45,6 +47,28 @@ func (r *bigQueryDestinationResource) Configure(_ context.Context, req resource.
 
 func (r *bigQueryDestinationResource) IdentitySchema(ctx context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
 	resp.IdentitySchema = BigQueryDestinationResourceIdentitySchema(ctx)
+}
+
+func (r *bigQueryDestinationResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config BigQueryDestinationModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Credentials.IsUnknown() {
+		return
+	}
+
+	credentials := config.Credentials.Value()
+
+	validateStringCredential(&resp.Diagnostics, credentials.ServiceAccountKey, credentials.ServiceAccountKeyWO, path.Root("credentials").AtName("service_account_key"), path.Root("credentials").AtName("service_account_key_wo"))
+}
+
+func (r *bigQueryDestinationResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanForWriteOnlyCredentialChange(ctx, req, resp, bigQueryDestinationModelWithWriteOnlyCredentials, NewTypedObjectUnknown[BigQueryDestinationConnectionDetails]())
 }
 
 func (r *bigQueryDestinationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -115,15 +139,24 @@ func (r *bigQueryDestinationResource) MoveState(ctx context.Context) []resource.
 
 //nolint:dupl
 func (r *bigQueryDestinationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan BigQueryDestinationModel
+	var plan, config BigQueryDestinationModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	createDestinationRequest, createDestinationRequestDiags := plan.ToCreateDestinationData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := bigQueryDestinationModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createDestinationRequest, createDestinationRequestDiags := requestModel.ToCreateDestinationData(ctx)
 	resp.Diagnostics.Append(createDestinationRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -133,9 +166,7 @@ func (r *bigQueryDestinationResource) Create(ctx context.Context, req resource.C
 	createDestinationResponse, createDestinationErr := r.providerData.client.CreateDestination(ctx, &createDestinationRequest)
 
 	tflog.Info(ctx, "destination.create", map[string]any{
-		"request":  createDestinationRequest,
-		"response": createDestinationResponse,
-		"err":      createDestinationErr,
+		"err": createDestinationErr,
 	})
 
 	if createDestinationResponse == nil {
@@ -160,18 +191,20 @@ func (r *bigQueryDestinationResource) Create(ctx context.Context, req resource.C
 	getDestinationResponse, getDestinationErr := r.providerData.client.GetDestination(ctx, getDestinationParams)
 
 	tflog.Info(ctx, "destination.read", map[string]any{
-		"request":  getDestinationParams,
-		"response": getDestinationResponse,
-		"err":      getDestinationErr,
+		"request": getDestinationParams,
+		"err":     getDestinationErr,
 	})
+
+	if getDestinationResponse == nil {
+		resp.Diagnostics.AddError("Failed to read destination after create", detailFromError(getDestinationErr))
+
+		return
+	}
 
 	model, modelDiags := NewBigQueryDestinationModelFromResponse(ctx, getDestinationResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedBigQueryDestinationCredentials(model, plan, config, model.ConnectionDetails.Value())
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -179,6 +212,7 @@ func (r *bigQueryDestinationResource) Create(ctx context.Context, req resource.C
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 func (r *bigQueryDestinationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -197,9 +231,8 @@ func (r *bigQueryDestinationResource) Read(ctx context.Context, req resource.Rea
 	getDestinationResponse, getDestinationErr := r.providerData.client.GetDestination(ctx, params)
 
 	tflog.Info(ctx, "destination.read", map[string]any{
-		"params":   params,
-		"response": getDestinationResponse,
-		"err":      getDestinationErr,
+		"params": params,
+		"err":    getDestinationErr,
 	})
 
 	if getDestinationResponse == nil {
@@ -222,9 +255,16 @@ func (r *bigQueryDestinationResource) Read(ctx context.Context, req resource.Rea
 	resp.Diagnostics.Append(modelDiags...)
 
 	credentials := state.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
+
+	connectionDetails := model.ConnectionDetails.Value()
+	if credentials.ServiceAccountKey.IsNull() {
+		connectionDetails.ServiceAccountKey = types.StringNull()
+	}
+
+	credentials.UpdateWithConnectionDetails(connectionDetails)
 
 	model.Credentials = NewTypedObject(credentials)
+	model.ConnectionDetails = NewTypedObject(connectionDetails)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -235,10 +275,11 @@ func (r *bigQueryDestinationResource) Read(ctx context.Context, req resource.Rea
 }
 
 func (r *bigQueryDestinationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state, plan BigQueryDestinationModel
+	var state, plan, config BigQueryDestinationModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -248,7 +289,15 @@ func (r *bigQueryDestinationResource) Update(ctx context.Context, req resource.U
 		DestinationID: plan.ID.ValueString(),
 	}
 
-	updateDestinationRequest, updateDestinationRequestDiags := plan.ToUpdateDestinationData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := bigQueryDestinationModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateDestinationRequest, updateDestinationRequestDiags := requestModel.ToUpdateDestinationData(ctx)
 	resp.Diagnostics.Append(updateDestinationRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -258,10 +307,8 @@ func (r *bigQueryDestinationResource) Update(ctx context.Context, req resource.U
 	updateDestinationResponse, updateDestinationErr := r.providerData.client.UpdateDestination(ctx, &updateDestinationRequest, params)
 
 	tflog.Info(ctx, "destination.update", map[string]any{
-		"params":   params,
-		"request":  updateDestinationRequest,
-		"response": updateDestinationResponse,
-		"err":      updateDestinationErr,
+		"params": params,
+		"err":    updateDestinationErr,
 	})
 
 	if updateDestinationResponse == nil {
@@ -273,13 +320,11 @@ func (r *bigQueryDestinationResource) Update(ctx context.Context, req resource.U
 	model, modelDiags := NewBigQueryDestinationModelFromResponse(ctx, updateDestinationResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedBigQueryDestinationCredentials(model, plan, config, model.ConnectionDetails.Value())
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 //nolint:dupl
@@ -299,9 +344,8 @@ func (r *bigQueryDestinationResource) Delete(ctx context.Context, req resource.D
 	deleteDestinationResponse, deleteDestinationErr := r.providerData.client.DeleteDestination(ctx, params)
 
 	tflog.Info(ctx, "destination.delete", map[string]any{
-		"params":   params,
-		"response": deleteDestinationResponse,
-		"err":      deleteDestinationErr,
+		"params": params,
+		"err":    deleteDestinationErr,
 	})
 
 	var srsc *cm.StatusResponseStatusCode

--- a/internal/provider/big_query_destination_resource_schema.go
+++ b/internal/provider/big_query_destination_resource_schema.go
@@ -54,7 +54,13 @@ func BigQueryDestinationCredentialsResourceSchemaAttributes(_ context.Context) m
 		"service_account_key": schema.StringAttribute{
 			Optional:            true,
 			Sensitive:           true,
-			MarkdownDescription: "Service account key JSON used by Census to write to BigQuery.",
+			MarkdownDescription: "Service account key JSON used by Census to write to BigQuery. Configure at most one of `service_account_key` or `service_account_key_wo`.",
+		},
+		"service_account_key_wo": schema.StringAttribute{
+			Optional:            true,
+			Sensitive:           true,
+			WriteOnly:           true,
+			MarkdownDescription: "Service account key JSON used by Census to write to BigQuery. Configure at most one of `service_account_key` or `service_account_key_wo`.",
 		},
 	}
 }

--- a/internal/provider/big_query_destination_resource_test.go
+++ b/internal/provider/big_query_destination_resource_test.go
@@ -133,6 +133,117 @@ func TestAccBigQueryDestinationResourceCreateUpdateDelete(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest
+func TestAccBigQueryDestinationResourceWriteOnlyCredentials(t *testing.T) {
+	server, err := cmt.NewCensusManagementServer()
+	require.NoError(t, err)
+
+	ProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "censusworkspace_big_query_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    project_id           = "project-id"
+    location             = "location"
+    service_account_key  = "service-account-key"
+  }
+}
+`,
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    project_id             = "project-id"
+    location               = "location"
+    service_account_key_wo = "service-account-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_big_query_destination.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("credentials").AtMapKey("service_account_key"), knownvalue.Null()),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("connection_details").AtMapKey("service_account_key"), knownvalue.Null()),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    project_id             = "project-id"
+    location               = "location"
+    service_account_key_wo = "rotated-service-account-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_big_query_destination.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("connection_details")),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("credentials").AtMapKey("service_account_key"), knownvalue.Null()),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("connection_details").AtMapKey("service_account_key"), knownvalue.Null()),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    project_id             = "project-id"
+    location               = "location"
+    service_account_key_wo = "rotated-service-account-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectResourceAction("censusworkspace_big_query_destination.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_destination" "test" {
+  name = "Test Destination (updated)"
+
+  credentials = {
+    project_id             = "project-id"
+    location               = "location"
+    service_account_key_wo = "rotated-service-account-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_big_query_destination.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Destination (updated)")),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("credentials").AtMapKey("service_account_key"), knownvalue.Null()),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("connection_details").AtMapKey("service_account_key"), knownvalue.Null()),
+					},
+				},
+			},
+		},
+	})
+}
+
 //nolint:dupl,paralleltest
 func TestAccBigQueryDestinationResourceMovedFromDestination(t *testing.T) {
 	server, err := cmt.NewCensusManagementServer()

--- a/internal/provider/big_query_source_credential_resolvers.go
+++ b/internal/provider/big_query_source_credential_resolvers.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func bigQuerySourceModelWithWriteOnlyCredentials(plan, config BigQuerySourceModel) (BigQuerySourceModel, writeOnlyCredentialValues, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	values := writeOnlyCredentialValues{}
+
+	model := plan
+	credentials := plan.Credentials.Value()
+	configCredentials := configuredObjectOrPlan(config.Credentials, plan.Credentials).Value()
+
+	credentials.ProjectID = configCredentials.ProjectID
+	credentials.Location = configCredentials.Location
+	credentials.ServiceAccountKey = configCredentials.ServiceAccountKey
+
+	serviceAccountKey, serviceAccountKeyOk := credentials.ServiceAccountKey.GetValue()
+	configServiceAccountKey, configServiceAccountKeyOk := configCredentials.ServiceAccountKey.GetValue()
+
+	if serviceAccountKeyOk {
+		privateKey, privateKeyDiags := resolveStringCredentialInput(stringCredentialInput{
+			Legacy:        configServiceAccountKey.PrivateKey,
+			WriteOnly:     configServiceAccountKey.PrivateKeyWO,
+			LegacyPath:    path.Root("credentials").AtName("service_account_key").AtName("private_key"),
+			WriteOnlyPath: path.Root("credentials").AtName("service_account_key").AtName("private_key_wo"),
+			Required:      true,
+		})
+		diags.Append(privateKeyDiags...)
+		diags.Append(privateKey.AddValueTo(values)...)
+
+		serviceAccountKey.PrivateKey = privateKey.Value
+
+		if privateKey.UsedWriteOnly {
+			serviceAccountKey.PrivateKeyWO = types.StringNull()
+		}
+
+		credentials.ServiceAccountKey = NewTypedObject(serviceAccountKey)
+	} else if configServiceAccountKeyOk && !configServiceAccountKey.PrivateKeyWO.IsNull() {
+		diags.AddError(
+			"Missing credential argument",
+			path.Root("credentials").AtName("service_account_key").AtName("private_key_wo").String()+" requires "+
+				path.Root("credentials").AtName("service_account_key").String()+" to be configured.",
+		)
+	}
+
+	model.Credentials = NewTypedObject(credentials)
+
+	return model, values, diags
+}
+
+func sanitizedBigQuerySourceCredentials(model, plan, config BigQuerySourceModel, connectionDetails BigQuerySourceConnectionDetails) BigQuerySourceModel {
+	credentials := plan.Credentials.Value()
+	configCredentials := config.Credentials.Value()
+
+	serviceAccountKey, serviceAccountKeyOk := credentials.ServiceAccountKey.GetValue()
+	configServiceAccountKey, configServiceAccountKeyOk := configCredentials.ServiceAccountKey.GetValue()
+
+	if serviceAccountKeyOk {
+		if configServiceAccountKeyOk && !configServiceAccountKey.PrivateKeyWO.IsNull() {
+			serviceAccountKey.PrivateKey = types.StringNull()
+		}
+
+		serviceAccountKey.PrivateKeyWO = types.StringNull()
+		credentials.ServiceAccountKey = NewTypedObject(serviceAccountKey)
+	}
+
+	credentials.UpdateWithConnectionDetails(connectionDetails)
+	model.Credentials = NewTypedObject(credentials)
+
+	return model
+}

--- a/internal/provider/big_query_source_model.go
+++ b/internal/provider/big_query_source_model.go
@@ -27,6 +27,7 @@ type BigQuerySourceCredentialsServiceAccountKey struct {
 	ProjectID    types.String `tfsdk:"project_id"`
 	PrivateKeyID types.String `tfsdk:"private_key_id"`
 	PrivateKey   types.String `tfsdk:"private_key"`
+	PrivateKeyWO types.String `tfsdk:"private_key_wo"`
 	ClientEmail  types.String `tfsdk:"client_email"`
 	ClientID     types.String `tfsdk:"client_id"`
 }

--- a/internal/provider/big_query_source_resource.go
+++ b/internal/provider/big_query_source_resource.go
@@ -15,11 +15,13 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*bigQuerySourceResource)(nil)
-	_ resource.ResourceWithConfigure   = (*bigQuerySourceResource)(nil)
-	_ resource.ResourceWithIdentity    = (*bigQuerySourceResource)(nil)
-	_ resource.ResourceWithImportState = (*bigQuerySourceResource)(nil)
-	_ resource.ResourceWithMoveState   = (*bigQuerySourceResource)(nil)
+	_ resource.Resource                   = (*bigQuerySourceResource)(nil)
+	_ resource.ResourceWithConfigure      = (*bigQuerySourceResource)(nil)
+	_ resource.ResourceWithIdentity       = (*bigQuerySourceResource)(nil)
+	_ resource.ResourceWithImportState    = (*bigQuerySourceResource)(nil)
+	_ resource.ResourceWithModifyPlan     = (*bigQuerySourceResource)(nil)
+	_ resource.ResourceWithMoveState      = (*bigQuerySourceResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*bigQuerySourceResource)(nil)
 )
 
 //nolint:ireturn
@@ -45,6 +47,39 @@ func (r *bigQuerySourceResource) Configure(_ context.Context, req resource.Confi
 
 func (r *bigQuerySourceResource) IdentitySchema(ctx context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
 	resp.IdentitySchema = BigQuerySourceResourceIdentitySchema(ctx)
+}
+
+func (r *bigQuerySourceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config BigQuerySourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Credentials.IsUnknown() {
+		return
+	}
+
+	credentials := config.Credentials.Value()
+
+	serviceAccountKey, ok := credentials.ServiceAccountKey.GetValue()
+	if !ok {
+		return
+	}
+
+	validateRequiredStringCredential(
+		&resp.Diagnostics,
+		serviceAccountKey.PrivateKey,
+		serviceAccountKey.PrivateKeyWO,
+		path.Root("credentials").AtName("service_account_key").AtName("private_key"),
+		path.Root("credentials").AtName("service_account_key").AtName("private_key_wo"),
+	)
+}
+
+func (r *bigQuerySourceResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanForWriteOnlyCredentialChange(ctx, req, resp, bigQuerySourceModelWithWriteOnlyCredentials, NewTypedObjectUnknown[BigQuerySourceConnectionDetails]())
 }
 
 func (r *bigQuerySourceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -133,15 +168,24 @@ func (r *bigQuerySourceResource) MoveState(ctx context.Context) []resource.State
 }
 
 func (r *bigQuerySourceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan BigQuerySourceModel
+	var plan, config BigQuerySourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	createSourceRequest, createSourceRequestDiags := plan.ToCreateSourceData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := bigQuerySourceModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createSourceRequest, createSourceRequestDiags := requestModel.ToCreateSourceData(ctx)
 	resp.Diagnostics.Append(createSourceRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -151,9 +195,7 @@ func (r *bigQuerySourceResource) Create(ctx context.Context, req resource.Create
 	createSourceResponse, createSourceErr := r.providerData.client.CreateSource(ctx, &createSourceRequest)
 
 	tflog.Info(ctx, "source.create", map[string]any{
-		"request":  createSourceRequest,
-		"response": createSourceResponse,
-		"err":      createSourceErr,
+		"err": createSourceErr,
 	})
 
 	if createSourceResponse == nil {
@@ -178,10 +220,15 @@ func (r *bigQuerySourceResource) Create(ctx context.Context, req resource.Create
 	getSourceResponse, getSourceErr := r.providerData.client.GetSource(ctx, getSourceParams)
 
 	tflog.Info(ctx, "source.read", map[string]any{
-		"request":  getSourceParams,
-		"response": getSourceResponse,
-		"err":      getSourceErr,
+		"request": getSourceParams,
+		"err":     getSourceErr,
 	})
+
+	if getSourceResponse == nil {
+		resp.Diagnostics.AddError("Failed to read source after create", detailFromError(getSourceErr))
+
+		return
+	}
 
 	model, modelDiags := NewBigQuerySourceModelFromResponse(ctx, getSourceResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
@@ -190,10 +237,7 @@ func (r *bigQuerySourceResource) Create(ctx context.Context, req resource.Create
 		model.SyncEngine = plan.SyncEngine
 	}
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedBigQuerySourceCredentials(model, plan, config, model.ConnectionDetails.Value())
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -201,6 +245,7 @@ func (r *bigQuerySourceResource) Create(ctx context.Context, req resource.Create
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 func (r *bigQuerySourceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -219,9 +264,8 @@ func (r *bigQuerySourceResource) Read(ctx context.Context, req resource.ReadRequ
 	getSourceResponse, getSourceErr := r.providerData.client.GetSource(ctx, params)
 
 	tflog.Info(ctx, "source.read", map[string]any{
-		"params":   params,
-		"response": getSourceResponse,
-		"err":      getSourceErr,
+		"params": params,
+		"err":    getSourceErr,
 	})
 
 	if getSourceResponse == nil {
@@ -261,10 +305,11 @@ func (r *bigQuerySourceResource) Read(ctx context.Context, req resource.ReadRequ
 }
 
 func (r *bigQuerySourceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state, plan BigQuerySourceModel
+	var state, plan, config BigQuerySourceModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -274,7 +319,15 @@ func (r *bigQuerySourceResource) Update(ctx context.Context, req resource.Update
 		SourceID: plan.ID.ValueString(),
 	}
 
-	updateSourceRequest, updateSourceRequestDiags := plan.ToUpdateSourceData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := bigQuerySourceModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateSourceRequest, updateSourceRequestDiags := requestModel.ToUpdateSourceData(ctx)
 	resp.Diagnostics.Append(updateSourceRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -284,10 +337,8 @@ func (r *bigQuerySourceResource) Update(ctx context.Context, req resource.Update
 	updateSourceResponse, updateSourceErr := r.providerData.client.UpdateSource(ctx, &updateSourceRequest, params)
 
 	tflog.Info(ctx, "source.update", map[string]any{
-		"params":   params,
-		"request":  updateSourceRequest,
-		"response": updateSourceResponse,
-		"err":      updateSourceErr,
+		"params": params,
+		"err":    updateSourceErr,
 	})
 
 	if updateSourceResponse == nil {
@@ -303,13 +354,11 @@ func (r *bigQuerySourceResource) Update(ctx context.Context, req resource.Update
 		model.SyncEngine = state.SyncEngine
 	}
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedBigQuerySourceCredentials(model, plan, config, model.ConnectionDetails.Value())
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 func (r *bigQuerySourceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -328,9 +377,8 @@ func (r *bigQuerySourceResource) Delete(ctx context.Context, req resource.Delete
 	deleteSourceResponse, deleteSourceErr := r.providerData.client.DeleteSource(ctx, params)
 
 	tflog.Info(ctx, "source.delete", map[string]any{
-		"params":   params,
-		"response": deleteSourceResponse,
-		"err":      deleteSourceErr,
+		"params": params,
+		"err":    deleteSourceErr,
 	})
 
 	var srsc *cm.StatusResponseStatusCode

--- a/internal/provider/big_query_source_resource_schema.go
+++ b/internal/provider/big_query_source_resource_schema.go
@@ -81,8 +81,14 @@ func BigQuerySourceCredentialsServiceAccountKeyResourceSchemaAttributes(_ contex
 		},
 		"private_key": schema.StringAttribute{
 			Sensitive:           true,
-			Required:            true,
-			MarkdownDescription: "Private key from the service account key JSON.",
+			Optional:            true,
+			MarkdownDescription: "Private key from the service account key JSON. Configure exactly one of `private_key` or `private_key_wo` when `service_account_key` is configured.",
+		},
+		"private_key_wo": schema.StringAttribute{
+			WriteOnly:           true,
+			Optional:            true,
+			Sensitive:           true,
+			MarkdownDescription: "Private key from the service account key JSON. Configure exactly one of `private_key` or `private_key_wo` when `service_account_key` is configured.",
 		},
 		"client_email": schema.StringAttribute{
 			Required:            true,

--- a/internal/provider/big_query_source_resource_test.go
+++ b/internal/provider/big_query_source_resource_test.go
@@ -163,6 +163,180 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 }
 
 //nolint:paralleltest
+func TestAccBigQuerySourceResourceWriteOnlyCredentials(t *testing.T) {
+	server, err := cmt.NewCensusManagementServer()
+	require.NoError(t, err)
+
+	ProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "censusworkspace_big_query_source" "test" {
+  name = "Test Source"
+
+  credentials = {
+    project_id = "project-id"
+    location   = "US"
+    service_account_key = {
+      type           = "service_account"
+      project_id     = "project-id"
+      private_key_id = "private-key-id"
+      private_key    = "private-key"
+      client_id      = "client-id"
+      client_email   = "client-email"
+    }
+  }
+}
+`,
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_source" "test" {
+  name = "Test Source"
+
+  credentials = {
+    project_id = "project-id"
+    location   = "US"
+    service_account_key = {
+      type           = "service_account"
+      project_id     = "project-id"
+      private_key_id = "private-key-id"
+      private_key_wo = "private-key"
+      client_id      = "client-id"
+      client_email   = "client-email"
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("credentials").AtMapKey("service_account_key").AtMapKey("private_key"), knownvalue.Null()),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_source" "test" {
+  name = "Test Source"
+
+  credentials = {
+    project_id = "project-id"
+    location   = "US"
+    service_account_key = {
+      type           = "service_account"
+      project_id     = "project-id"
+      private_key_id = "private-key-id"
+      private_key_wo = "rotated-private-key"
+      client_id      = "client-id"
+      client_email   = "client-email"
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue("censusworkspace_big_query_source.test", tfjsonpath.New("connection_details")),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("credentials").AtMapKey("service_account_key").AtMapKey("private_key"), knownvalue.Null()),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_source" "test" {
+  name = "Test Source"
+
+  credentials = {
+    project_id = "project-id"
+    location   = "US"
+    service_account_key = {
+      type           = "service_account"
+      project_id     = "project-id"
+      private_key_id = "private-key-id"
+      private_key_wo = "rotated-private-key"
+      client_id      = "client-id"
+      client_email   = "client-email"
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_big_query_source" "test" {
+  name = "Test Source (updated)"
+
+  credentials = {
+    project_id = "project-id"
+    location   = "US"
+    service_account_key = {
+      type           = "service_account"
+      project_id     = "project-id"
+      private_key_id = "private-key-id"
+      private_key_wo = "rotated-private-key"
+      client_id      = "client-id"
+      client_email   = "client-email"
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_big_query_source.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source (updated)")),
+						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("credentials").AtMapKey("service_account_key").AtMapKey("private_key"), knownvalue.Null()),
+					},
+				},
+			},
+		},
+	})
+}
+
+//nolint:paralleltest
+func TestAccBigQuerySourceResourceMissingServiceAccountPrivateKey(t *testing.T) {
+	server, err := cmt.NewCensusManagementServer()
+	require.NoError(t, err)
+
+	ProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "censusworkspace_big_query_source" "test" {
+  name = "Test Source"
+
+  credentials = {
+    project_id = "project-id"
+    location   = "US"
+    service_account_key = {
+      type           = "service_account"
+      project_id     = "project-id"
+      private_key_id = "private-key-id"
+      client_id      = "client-id"
+      client_email   = "client-email"
+    }
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`One of credentials\.service_account_key\.private_key or\s+credentials\.service_account_key\.private_key_wo must be configured`),
+			},
+		},
+	})
+}
+
+//nolint:paralleltest
 func TestAccBigQuerySourceResourceMovedFromSource(t *testing.T) {
 	server, err := cmt.NewCensusManagementServer()
 	require.NoError(t, err)

--- a/internal/provider/braze_destination_credential_resolvers.go
+++ b/internal/provider/braze_destination_credential_resolvers.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func brazeDestinationModelWithWriteOnlyCredentials(plan, config BrazeDestinationModel) (BrazeDestinationModel, writeOnlyCredentialValues, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	values := writeOnlyCredentialValues{}
+
+	model := plan
+	credentials := plan.Credentials.Value()
+	configCredentials := configuredObjectOrPlan(config.Credentials, plan.Credentials).Value()
+
+	credentials.InstanceURL = configCredentials.InstanceURL
+
+	apiKeyValue := configCredentials.APIKey
+	if config.Credentials.IsUnknown() && stringKnown(credentials.APIKey) {
+		apiKeyValue = credentials.APIKey
+	}
+
+	apiKey, apiKeyDiags := resolveStringCredentialInput(stringCredentialInput{
+		Legacy:        apiKeyValue,
+		WriteOnly:     configCredentials.APIKeyWO,
+		LegacyPath:    path.Root("credentials").AtName("api_key"),
+		WriteOnlyPath: path.Root("credentials").AtName("api_key_wo"),
+		Required:      true,
+	})
+	diags.Append(apiKeyDiags...)
+	diags.Append(apiKey.AddValueTo(values)...)
+
+	if apiKey.UsedWriteOnly {
+		credentials.APIKeyWO = types.StringNull()
+	}
+
+	credentials.APIKey = apiKey.Value
+
+	clientKeyValue := configCredentials.ClientKey
+	if !stringKnown(clientKeyValue) && stringKnown(credentials.ClientKey) {
+		clientKeyValue = credentials.ClientKey
+	}
+
+	clientKey, clientKeyDiags := resolveStringCredentialInput(stringCredentialInput{
+		Legacy:        clientKeyValue,
+		WriteOnly:     configCredentials.ClientKeyWO,
+		LegacyPath:    path.Root("credentials").AtName("client_key"),
+		WriteOnlyPath: path.Root("credentials").AtName("client_key_wo"),
+	})
+	diags.Append(clientKeyDiags...)
+	diags.Append(clientKey.AddValueTo(values)...)
+
+	if clientKey.UsedWriteOnly {
+		credentials.ClientKeyWO = types.StringNull()
+	}
+
+	credentials.ClientKey = clientKey.Value
+
+	model.Credentials = NewTypedObject(credentials)
+
+	return model, values, diags
+}
+
+func sanitizedBrazeDestinationCredentials(model, plan, config BrazeDestinationModel, connectionDetails BrazeDestinationConnectionDetails) BrazeDestinationModel {
+	credentials := plan.Credentials.Value()
+	configCredentials := config.Credentials.Value()
+
+	if !configCredentials.APIKeyWO.IsNull() {
+		credentials.APIKey = types.StringNull()
+	}
+
+	if !configCredentials.ClientKeyWO.IsNull() {
+		credentials.ClientKey = types.StringNull()
+	}
+
+	credentials.APIKeyWO = types.StringNull()
+	credentials.ClientKeyWO = types.StringNull()
+	credentials.UpdateWithConnectionDetails(connectionDetails)
+
+	model.Credentials = NewTypedObject(credentials)
+
+	return model
+}

--- a/internal/provider/braze_destination_model.go
+++ b/internal/provider/braze_destination_model.go
@@ -19,7 +19,9 @@ type BrazeDestinationModel struct {
 type BrazeDestinationCredentials struct {
 	InstanceURL types.String `tfsdk:"instance_url"`
 	APIKey      types.String `tfsdk:"api_key"`
+	APIKeyWO    types.String `tfsdk:"api_key_wo"`
 	ClientKey   types.String `tfsdk:"client_key"`
+	ClientKeyWO types.String `tfsdk:"client_key_wo"`
 }
 
 type BrazeDestinationConnectionDetails struct {

--- a/internal/provider/braze_destination_resource.go
+++ b/internal/provider/braze_destination_resource.go
@@ -15,11 +15,13 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*brazeDestinationResource)(nil)
-	_ resource.ResourceWithConfigure   = (*brazeDestinationResource)(nil)
-	_ resource.ResourceWithIdentity    = (*brazeDestinationResource)(nil)
-	_ resource.ResourceWithImportState = (*brazeDestinationResource)(nil)
-	_ resource.ResourceWithMoveState   = (*brazeDestinationResource)(nil)
+	_ resource.Resource                   = (*brazeDestinationResource)(nil)
+	_ resource.ResourceWithConfigure      = (*brazeDestinationResource)(nil)
+	_ resource.ResourceWithIdentity       = (*brazeDestinationResource)(nil)
+	_ resource.ResourceWithImportState    = (*brazeDestinationResource)(nil)
+	_ resource.ResourceWithModifyPlan     = (*brazeDestinationResource)(nil)
+	_ resource.ResourceWithMoveState      = (*brazeDestinationResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*brazeDestinationResource)(nil)
 )
 
 //nolint:ireturn
@@ -45,6 +47,43 @@ func (r *brazeDestinationResource) Configure(_ context.Context, req resource.Con
 
 func (r *brazeDestinationResource) IdentitySchema(ctx context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
 	resp.IdentitySchema = BrazeDestinationResourceIdentitySchema(ctx)
+}
+
+func (r *brazeDestinationResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config BrazeDestinationModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Credentials.IsUnknown() {
+		return
+	}
+
+	apiKeyPath := path.Root("credentials").AtName("api_key")
+	apiKeyWOPath := path.Root("credentials").AtName("api_key_wo")
+	clientKeyPath := path.Root("credentials").AtName("client_key")
+	clientKeyWOPath := path.Root("credentials").AtName("client_key_wo")
+
+	var apiKey, apiKeyWO, clientKey, clientKeyWO types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, apiKeyPath, &apiKey)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, apiKeyWOPath, &apiKeyWO)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, clientKeyPath, &clientKey)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, clientKeyWOPath, &clientKeyWO)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	validateRequiredStringCredential(&resp.Diagnostics, apiKey, apiKeyWO, apiKeyPath, apiKeyWOPath)
+	validateStringCredential(&resp.Diagnostics, clientKey, clientKeyWO, clientKeyPath, clientKeyWOPath)
+}
+
+func (r *brazeDestinationResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanForWriteOnlyCredentialChange(ctx, req, resp, brazeDestinationModelWithWriteOnlyCredentials, NewTypedObjectUnknown[BrazeDestinationConnectionDetails]())
 }
 
 func (r *brazeDestinationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -109,15 +148,24 @@ func (r *brazeDestinationResource) MoveState(ctx context.Context) []resource.Sta
 
 //nolint:dupl
 func (r *brazeDestinationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan BrazeDestinationModel
+	var plan, config BrazeDestinationModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	createDestinationRequest, createDestinationRequestDiags := plan.ToCreateDestinationData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := brazeDestinationModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createDestinationRequest, createDestinationRequestDiags := requestModel.ToCreateDestinationData(ctx)
 	resp.Diagnostics.Append(createDestinationRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -127,9 +175,7 @@ func (r *brazeDestinationResource) Create(ctx context.Context, req resource.Crea
 	createDestinationResponse, createDestinationErr := r.providerData.client.CreateDestination(ctx, &createDestinationRequest)
 
 	tflog.Info(ctx, "destination.create", map[string]any{
-		"request":  createDestinationRequest,
-		"response": createDestinationResponse,
-		"err":      createDestinationErr,
+		"err": createDestinationErr,
 	})
 
 	if createDestinationResponse == nil {
@@ -154,18 +200,20 @@ func (r *brazeDestinationResource) Create(ctx context.Context, req resource.Crea
 	getDestinationResponse, getDestinationErr := r.providerData.client.GetDestination(ctx, getDestinationParams)
 
 	tflog.Info(ctx, "destination.read", map[string]any{
-		"request":  getDestinationParams,
-		"response": getDestinationResponse,
-		"err":      getDestinationErr,
+		"request": getDestinationParams,
+		"err":     getDestinationErr,
 	})
+
+	if getDestinationResponse == nil {
+		resp.Diagnostics.AddError("Failed to read destination after create", detailFromError(getDestinationErr))
+
+		return
+	}
 
 	model, modelDiags := NewBrazeDestinationModelFromResponse(ctx, getDestinationResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedBrazeDestinationCredentials(model, plan, config, model.ConnectionDetails.Value())
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -173,6 +221,7 @@ func (r *brazeDestinationResource) Create(ctx context.Context, req resource.Crea
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 func (r *brazeDestinationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -191,9 +240,8 @@ func (r *brazeDestinationResource) Read(ctx context.Context, req resource.ReadRe
 	getDestinationResponse, getDestinationErr := r.providerData.client.GetDestination(ctx, params)
 
 	tflog.Info(ctx, "destination.read", map[string]any{
-		"params":   params,
-		"response": getDestinationResponse,
-		"err":      getDestinationErr,
+		"params": params,
+		"err":    getDestinationErr,
 	})
 
 	if getDestinationResponse == nil {
@@ -229,10 +277,11 @@ func (r *brazeDestinationResource) Read(ctx context.Context, req resource.ReadRe
 }
 
 func (r *brazeDestinationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state, plan BrazeDestinationModel
+	var state, plan, config BrazeDestinationModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -242,7 +291,15 @@ func (r *brazeDestinationResource) Update(ctx context.Context, req resource.Upda
 		DestinationID: plan.ID.ValueString(),
 	}
 
-	updateDestinationRequest, updateDestinationRequestDiags := plan.ToUpdateDestinationData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := brazeDestinationModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateDestinationRequest, updateDestinationRequestDiags := requestModel.ToUpdateDestinationData(ctx)
 	resp.Diagnostics.Append(updateDestinationRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -252,10 +309,8 @@ func (r *brazeDestinationResource) Update(ctx context.Context, req resource.Upda
 	updateDestinationResponse, updateDestinationErr := r.providerData.client.UpdateDestination(ctx, &updateDestinationRequest, params)
 
 	tflog.Info(ctx, "destination.update", map[string]any{
-		"params":   params,
-		"request":  updateDestinationRequest,
-		"response": updateDestinationResponse,
-		"err":      updateDestinationErr,
+		"params": params,
+		"err":    updateDestinationErr,
 	})
 
 	if updateDestinationResponse == nil {
@@ -267,13 +322,11 @@ func (r *brazeDestinationResource) Update(ctx context.Context, req resource.Upda
 	model, modelDiags := NewBrazeDestinationModelFromResponse(ctx, updateDestinationResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedBrazeDestinationCredentials(model, plan, config, model.ConnectionDetails.Value())
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 //nolint:dupl
@@ -293,9 +346,8 @@ func (r *brazeDestinationResource) Delete(ctx context.Context, req resource.Dele
 	deleteDestinationResponse, deleteDestinationErr := r.providerData.client.DeleteDestination(ctx, params)
 
 	tflog.Info(ctx, "destination.delete", map[string]any{
-		"params":   params,
-		"response": deleteDestinationResponse,
-		"err":      deleteDestinationErr,
+		"params": params,
+		"err":    deleteDestinationErr,
 	})
 
 	var srsc *cm.StatusResponseStatusCode

--- a/internal/provider/braze_destination_resource_schema.go
+++ b/internal/provider/braze_destination_resource_schema.go
@@ -48,14 +48,26 @@ func BrazeDestinationCredentialsResourceSchemaAttributes(_ context.Context) map[
 			MarkdownDescription: "Braze REST API endpoint URL for the destination instance.",
 		},
 		"api_key": schema.StringAttribute{
-			Required:            true,
+			Optional:            true,
 			Sensitive:           true,
-			MarkdownDescription: "Braze REST API key Census uses to update users.",
+			MarkdownDescription: "Braze REST API key Census uses to update users. Configure exactly one of `api_key` or `api_key_wo`.",
+		},
+		"api_key_wo": schema.StringAttribute{
+			Optional:            true,
+			Sensitive:           true,
+			WriteOnly:           true,
+			MarkdownDescription: "Braze REST API key Census uses to update users. Configure exactly one of `api_key` or `api_key_wo`.",
 		},
 		"client_key": schema.StringAttribute{
 			Optional:            true,
 			Sensitive:           true,
-			MarkdownDescription: "Braze Data Import Key used when syncing Cohorts.",
+			MarkdownDescription: "Braze Data Import Key used when syncing Cohorts. Configure at most one of `client_key` or `client_key_wo`.",
+		},
+		"client_key_wo": schema.StringAttribute{
+			Optional:            true,
+			Sensitive:           true,
+			WriteOnly:           true,
+			MarkdownDescription: "Braze Data Import Key used when syncing Cohorts. Configure at most one of `client_key` or `client_key_wo`.",
 		},
 	}
 }

--- a/internal/provider/braze_destination_resource_test.go
+++ b/internal/provider/braze_destination_resource_test.go
@@ -134,6 +134,132 @@ func TestAccBrazeDestinationResourceCreateUpdateDelete(t *testing.T) {
 }
 
 //nolint:paralleltest
+func TestAccBrazeDestinationResourceWriteOnlyCredentials(t *testing.T) {
+	server, err := cmt.NewCensusManagementServer()
+	require.NoError(t, err)
+
+	ProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "censusworkspace_braze_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    instance_url = "instance-url"
+    api_key      = "api-key"
+  }
+}
+`,
+			},
+			{
+				Config: `
+resource "censusworkspace_braze_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    instance_url = "instance-url"
+    api_key_wo   = "api-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_braze_destination.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("credentials").AtMapKey("api_key"), knownvalue.Null()),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_braze_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    instance_url = "instance-url"
+    api_key_wo   = "rotated-api-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_braze_destination.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue("censusworkspace_braze_destination.test", tfjsonpath.New("connection_details")),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("credentials").AtMapKey("api_key"), knownvalue.Null()),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_braze_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    instance_url = "instance-url"
+    api_key_wo   = "rotated-api-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectResourceAction("censusworkspace_braze_destination.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_braze_destination" "test" {
+  name = "Test Destination (updated)"
+
+  credentials = {
+    instance_url = "instance-url"
+    api_key_wo   = "rotated-api-key"
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_braze_destination.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Destination (updated)")),
+						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("credentials").AtMapKey("api_key"), knownvalue.Null()),
+					},
+				},
+			},
+		},
+	})
+}
+
+//nolint:paralleltest
+func TestAccBrazeDestinationResourceMissingAPIKey(t *testing.T) {
+	server, err := cmt.NewCensusManagementServer()
+	require.NoError(t, err)
+
+	ProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "censusworkspace_braze_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    instance_url = "instance-url"
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`One of credentials\.api_key or credentials\.api_key_wo must be configured`),
+			},
+		},
+	})
+}
+
+//nolint:paralleltest
 func TestAccBrazeDestinationResourceMovedFromDestination(t *testing.T) {
 	server, err := cmt.NewCensusManagementServer()
 	require.NoError(t, err)

--- a/internal/provider/credential_resolvers.go
+++ b/internal/provider/credential_resolvers.go
@@ -1,0 +1,47 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type stringCredentialInput struct {
+	Legacy        types.String
+	WriteOnly     types.String
+	LegacyPath    path.Path
+	WriteOnlyPath path.Path
+	Required      bool
+}
+
+type resolvedStringCredential struct {
+	Value         types.String
+	UsedWriteOnly bool
+	WriteOnlyPath path.Path
+}
+
+func (c resolvedStringCredential) AddValueTo(values writeOnlyCredentialValues) diag.Diagnostics {
+	if c.UsedWriteOnly {
+		return values.Add(c.WriteOnlyPath, c.Value)
+	}
+
+	return nil
+}
+
+func resolveStringCredentialInput(input stringCredentialInput) (resolvedStringCredential, diag.Diagnostics) {
+	value, usedWriteOnly, diags := resolveStringCredential(input.Legacy, input.WriteOnly, input.LegacyPath, input.WriteOnlyPath, input.Required)
+
+	return resolvedStringCredential{
+		Value:         value,
+		UsedWriteOnly: usedWriteOnly,
+		WriteOnlyPath: input.WriteOnlyPath,
+	}, diags
+}
+
+func configuredObjectOrPlan[T any](configured, planned TypedObject[T]) TypedObject[T] {
+	if configured.IsNull() || configured.IsUnknown() {
+		return planned
+	}
+
+	return configured
+}

--- a/internal/provider/custom_api_destination_connection_details_response.go
+++ b/internal/provider/custom_api_destination_connection_details_response.go
@@ -46,7 +46,7 @@ func (cd *CustomAPIDestinationConnectionDetails) Decode(dec *jx.Decoder) error {
 	})
 }
 
-func DecodeConnectionDetailsCustomHeadersMap(dec *jx.Decoder, value *TypedMap[TypedObject[CustomAPIDestinationCustomHeader]]) error {
+func DecodeConnectionDetailsCustomHeadersMap(dec *jx.Decoder, value *TypedMap[TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]]) error {
 	if dec.Next() == jx.Null {
 		err := dec.Null()
 		if err != nil {
@@ -54,15 +54,15 @@ func DecodeConnectionDetailsCustomHeadersMap(dec *jx.Decoder, value *TypedMap[Ty
 			return err
 		}
 
-		*value = NewTypedMapNull[TypedObject[CustomAPIDestinationCustomHeader]]()
+		*value = NewTypedMapNull[TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]]()
 
 		return nil
 	}
 
-	customHeaders := make(map[string]TypedObject[CustomAPIDestinationCustomHeader], 0)
+	customHeaders := make(map[string]TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader], 0)
 
 	customHeadersDecodeErr := dec.Obj(func(d *jx.Decoder, key string) error {
-		customHeader := CustomAPIDestinationCustomHeader{}
+		customHeader := CustomAPIDestinationConnectionDetailsCustomHeader{}
 
 		customHeaderDecodeErr := customHeader.Decode(d)
 		if customHeaderDecodeErr != nil {
@@ -83,7 +83,7 @@ func DecodeConnectionDetailsCustomHeadersMap(dec *jx.Decoder, value *TypedMap[Ty
 	return nil
 }
 
-func (ch *CustomAPIDestinationCustomHeader) Decode(dec *jx.Decoder) error {
+func (ch *CustomAPIDestinationConnectionDetailsCustomHeader) Decode(dec *jx.Decoder) error {
 	//nolint:wrapcheck
 	return dec.Obj(func(dec *jx.Decoder, key string) error {
 		switch key {

--- a/internal/provider/custom_api_destination_connection_details_response_test.go
+++ b/internal/provider/custom_api_destination_connection_details_response_test.go
@@ -36,7 +36,7 @@ func TestNewCustomAPIDestinationConnectionDetailsFromResponse(t *testing.T) {
 			expected: NewTypedObject(CustomAPIDestinationConnectionDetails{
 				APIVersion:    types.Int64Value(1),
 				WebhookURL:    types.StringValue("https://example.org/census-destination"),
-				CustomHeaders: NewTypedMapNull[TypedObject[CustomAPIDestinationCustomHeader]](),
+				CustomHeaders: NewTypedMapNull[TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]](),
 			}),
 		},
 		"webhook_url, custom_headers": {
@@ -44,8 +44,8 @@ func TestNewCustomAPIDestinationConnectionDetailsFromResponse(t *testing.T) {
 			expected: NewTypedObject(CustomAPIDestinationConnectionDetails{
 				APIVersion: types.Int64Value(1),
 				WebhookURL: types.StringValue("https://example.org/census-destination"),
-				CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationCustomHeader]{
-					"x-client-id": NewTypedObject(CustomAPIDestinationCustomHeader{
+				CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]{
+					"x-client-id": NewTypedObject(CustomAPIDestinationConnectionDetailsCustomHeader{
 						Value:    types.StringValue("client-id"),
 						IsSecret: types.BoolNull(),
 					}),
@@ -57,12 +57,12 @@ func TestNewCustomAPIDestinationConnectionDetailsFromResponse(t *testing.T) {
 			expected: NewTypedObject(CustomAPIDestinationConnectionDetails{
 				APIVersion: types.Int64Value(1),
 				WebhookURL: types.StringValue("https://example.org/census-destination"),
-				CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationCustomHeader]{
-					"x-client-id": NewTypedObject(CustomAPIDestinationCustomHeader{
+				CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]{
+					"x-client-id": NewTypedObject(CustomAPIDestinationConnectionDetailsCustomHeader{
 						Value:    types.StringValue("client-id"),
 						IsSecret: types.BoolValue(false),
 					}),
-					"x-client-secret": NewTypedObject(CustomAPIDestinationCustomHeader{
+					"x-client-secret": NewTypedObject(CustomAPIDestinationConnectionDetailsCustomHeader{
 						Value:    types.StringNull(),
 						IsSecret: types.BoolValue(true),
 					}),

--- a/internal/provider/custom_api_destination_credential_resolvers.go
+++ b/internal/provider/custom_api_destination_credential_resolvers.go
@@ -1,0 +1,218 @@
+package provider
+
+import (
+	"context"
+	"maps"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func customAPIDestinationModelWithWriteOnlyCredentials(plan, config CustomAPIDestinationModel) (CustomAPIDestinationModel, writeOnlyCredentialValues, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	values := writeOnlyCredentialValues{}
+
+	model := plan
+	credentials := plan.Credentials.Value()
+	configCredentials := config.Credentials.Value()
+
+	if credentials.CustomHeaders.IsNull() || credentials.CustomHeaders.IsUnknown() {
+		model.Credentials = NewTypedObject(credentials)
+
+		return model, values, diags
+	}
+
+	headers := make(map[string]TypedObject[CustomAPIDestinationCustomHeader], len(credentials.CustomHeaders.Elements()))
+
+	configHeaders := map[string]TypedObject[CustomAPIDestinationCustomHeader]{}
+	if !configCredentials.CustomHeaders.IsNull() && !configCredentials.CustomHeaders.IsUnknown() {
+		configHeaders = configCredentials.CustomHeaders.Elements()
+	}
+
+	for key, header := range credentials.CustomHeaders.Elements() {
+		headerValue := header.Value()
+		if configHeader, ok := configHeaders[key]; ok {
+			configHeaderValue := configHeader.Value()
+			writeOnlyPath := customAPIHeaderValueWOPath(key)
+			value, valueDiags := resolveStringCredentialInput(stringCredentialInput{
+				Legacy:        headerValue.Value,
+				WriteOnly:     configHeaderValue.ValueWO,
+				LegacyPath:    customAPIHeaderValuePath(key),
+				WriteOnlyPath: writeOnlyPath,
+				Required:      true,
+			})
+			diags.Append(valueDiags...)
+			diags.Append(value.AddValueTo(values)...)
+
+			headerValue.Value = value.Value
+			if value.UsedWriteOnly {
+				headerValue.ValueWO = types.StringNull()
+			}
+		}
+
+		headerValue.ValueWO = types.StringNull()
+		headers[key] = NewTypedObject(headerValue)
+	}
+
+	credentials.CustomHeaders = NewTypedMap(headers)
+	model.Credentials = NewTypedObject(credentials)
+
+	return model, values, diags
+}
+
+func hydrateCustomAPIHeaderWriteOnlyValues(ctx context.Context, config tfsdk.Config, model *CustomAPIDestinationModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	credentials := model.Credentials.Value()
+	if credentials.CustomHeaders.IsNull() || credentials.CustomHeaders.IsUnknown() {
+		return diags
+	}
+
+	headers := maps.Clone(credentials.CustomHeaders.Elements())
+	for key, header := range headers {
+		var value types.String
+
+		diags.Append(config.GetAttribute(ctx, customAPIHeaderValueWOPath(key), &value)...)
+
+		if diags.HasError() {
+			return diags
+		}
+
+		headerValue := header.Value()
+		headerValue.ValueWO = value
+		headers[key] = NewTypedObject(headerValue)
+	}
+
+	credentials.CustomHeaders = NewTypedMap(headers)
+	model.Credentials = NewTypedObject(credentials)
+
+	return diags
+}
+
+func customAPIHeaderValuePath(key string) path.Path {
+	return path.Root("credentials").AtName("custom_headers").AtMapKey(key).AtName("value")
+}
+
+func customAPIHeaderValueWOPath(key string) path.Path {
+	return path.Root("credentials").AtName("custom_headers").AtMapKey(key).AtName("value_wo")
+}
+
+func sanitizedCustomAPIDestinationCredentials(model, plan, config CustomAPIDestinationModel, connectionDetails CustomAPIDestinationConnectionDetails, writeOnlyValues writeOnlyCredentialValues) CustomAPIDestinationModel {
+	credentials := plan.Credentials.Value()
+	configCredentials := config.Credentials.Value()
+
+	credentials.APIVersion = connectionDetails.APIVersion
+	credentials.WebhookURL = connectionDetails.WebhookURL
+
+	if connectionDetails.CustomHeaders.IsNull() || connectionDetails.CustomHeaders.IsUnknown() {
+		credentials.CustomHeaders = NewTypedMapNull[TypedObject[CustomAPIDestinationCustomHeader]]()
+		model.Credentials = NewTypedObject(credentials)
+
+		return model
+	}
+
+	headers := mergeCustomAPIHeaders(
+		credentials.CustomHeaders,
+		configCredentials.CustomHeaders,
+		connectionDetails.CustomHeaders,
+		writeOnlyValues,
+	)
+	credentials.CustomHeaders = NewTypedMap(headers)
+	model.Credentials = NewTypedObject(credentials)
+	model.ConnectionDetails = NewTypedObject(sanitizedCustomAPIConnectionDetails(connectionDetails, credentials.CustomHeaders, writeOnlyValues))
+
+	return model
+}
+
+func mergeCustomAPIHeaders(
+	planned TypedMap[TypedObject[CustomAPIDestinationCustomHeader]],
+	configured TypedMap[TypedObject[CustomAPIDestinationCustomHeader]],
+	returned TypedMap[TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]],
+	writeOnlyValues writeOnlyCredentialValues,
+) map[string]TypedObject[CustomAPIDestinationCustomHeader] {
+	plannedHeaders := map[string]TypedObject[CustomAPIDestinationCustomHeader]{}
+	if !planned.IsNull() && !planned.IsUnknown() {
+		plannedHeaders = planned.Elements()
+	}
+
+	configuredHeaders := map[string]TypedObject[CustomAPIDestinationCustomHeader]{}
+	if !configured.IsNull() && !configured.IsUnknown() {
+		configuredHeaders = configured.Elements()
+	}
+
+	headers := make(map[string]TypedObject[CustomAPIDestinationCustomHeader])
+
+	keys := slices.Sorted(maps.Keys(returned.Elements()))
+	for _, key := range keys {
+		returnedHeader := returned.Elements()[key].Value()
+		header := CustomAPIDestinationCustomHeader{
+			Value:    returnedHeader.Value,
+			IsSecret: returnedHeader.IsSecret,
+			ValueWO:  types.StringNull(),
+		}
+
+		plannedHeader, plannedHeaderOk := plannedHeaders[key]
+		configuredHeader, configuredHeaderOk := configuredHeaders[key]
+
+		headerUsesWriteOnlyValue, pathDiags := writeOnlyValues.Configured(customAPIHeaderValueWOPath(key))
+		if pathDiags.HasError() {
+			continue
+		}
+
+		switch {
+		case headerUsesWriteOnlyValue:
+			header.Value = types.StringNull()
+		case configuredHeaderOk && !configuredHeader.Value().ValueWO.IsNull():
+			header.Value = types.StringNull()
+		case plannedHeaderOk && plannedHeader.Value().Value.IsNull():
+			header.Value = types.StringNull()
+		case header.Value.IsNull() && plannedHeaderOk:
+			header.Value = plannedHeader.Value().Value
+		}
+
+		headers[key] = NewTypedObject(header)
+	}
+
+	return headers
+}
+
+func sanitizedCustomAPIConnectionDetails(
+	connectionDetails CustomAPIDestinationConnectionDetails,
+	credentialsHeaders TypedMap[TypedObject[CustomAPIDestinationCustomHeader]],
+	writeOnlyValues writeOnlyCredentialValues,
+) CustomAPIDestinationConnectionDetails {
+	if connectionDetails.CustomHeaders.IsNull() || connectionDetails.CustomHeaders.IsUnknown() || credentialsHeaders.IsNull() || credentialsHeaders.IsUnknown() {
+		return connectionDetails
+	}
+
+	credentialHeaders := credentialsHeaders.Elements()
+	connectionHeaders := maps.Clone(connectionDetails.CustomHeaders.Elements())
+
+	for key, credentialHeader := range credentialHeaders {
+		connectionHeader, ok := connectionHeaders[key]
+		if !ok {
+			continue
+		}
+
+		headerUsesWriteOnlyValue, pathDiags := writeOnlyValues.Configured(customAPIHeaderValueWOPath(key))
+		if pathDiags.HasError() {
+			continue
+		}
+
+		if !headerUsesWriteOnlyValue && !credentialHeader.Value().Value.IsNull() {
+			continue
+		}
+
+		connectionHeaderValue := connectionHeader.Value()
+		connectionHeaderValue.Value = types.StringNull()
+		connectionHeaders[key] = NewTypedObject(connectionHeaderValue)
+	}
+
+	connectionDetails.CustomHeaders = NewTypedMap(connectionHeaders)
+
+	return connectionDetails
+}

--- a/internal/provider/custom_api_destination_credentials.go
+++ b/internal/provider/custom_api_destination_credentials.go
@@ -5,7 +5,7 @@ func (c *CustomAPIDestinationCredentials) UpdateWithConnectionDetails(connection
 	c.WebhookURL = connectionDetails.WebhookURL
 
 	if connectionDetails.CustomHeaders.IsNull() || connectionDetails.CustomHeaders.IsUnknown() {
-		c.CustomHeaders = connectionDetails.CustomHeaders
+		c.CustomHeaders = NewTypedMapNull[TypedObject[CustomAPIDestinationCustomHeader]]()
 	} else {
 		existingCustomHeaders := c.CustomHeaders.Elements()
 
@@ -14,7 +14,11 @@ func (c *CustomAPIDestinationCredentials) UpdateWithConnectionDetails(connection
 		for key, value := range connectionDetails.CustomHeaders.Elements() {
 			existingHeader, existingHeaderOk := existingCustomHeaders[key]
 
-			customHeader := value.Value()
+			connectionDetailsHeader := value.Value()
+			customHeader := CustomAPIDestinationCustomHeader{
+				Value:    connectionDetailsHeader.Value,
+				IsSecret: connectionDetailsHeader.IsSecret,
+			}
 
 			if customHeader.Value.IsNull() && existingHeaderOk {
 				customHeader.Value = existingHeader.Value().Value

--- a/internal/provider/custom_api_destination_model.go
+++ b/internal/provider/custom_api_destination_model.go
@@ -23,13 +23,18 @@ type CustomAPIDestinationCredentials struct {
 }
 
 type CustomAPIDestinationConnectionDetails struct {
-	APIVersion    types.Int64                                             `tfsdk:"api_version"`
-	WebhookURL    types.String                                            `tfsdk:"webhook_url"`
-	CustomHeaders TypedMap[TypedObject[CustomAPIDestinationCustomHeader]] `tfsdk:"custom_headers"`
+	APIVersion    types.Int64                                                              `tfsdk:"api_version"`
+	WebhookURL    types.String                                                             `tfsdk:"webhook_url"`
+	CustomHeaders TypedMap[TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]] `tfsdk:"custom_headers"`
 }
 
-//nolint:recvcheck
 type CustomAPIDestinationCustomHeader struct {
+	Value    types.String `tfsdk:"value"`
+	ValueWO  types.String `tfsdk:"value_wo"`
+	IsSecret types.Bool   `tfsdk:"is_secret"`
+}
+
+type CustomAPIDestinationConnectionDetailsCustomHeader struct {
 	Value    types.String `tfsdk:"value"`
 	IsSecret types.Bool   `tfsdk:"is_secret"`
 }

--- a/internal/provider/custom_api_destination_resource.go
+++ b/internal/provider/custom_api_destination_resource.go
@@ -14,11 +14,13 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*customAPIDestinationResource)(nil)
-	_ resource.ResourceWithConfigure   = (*customAPIDestinationResource)(nil)
-	_ resource.ResourceWithIdentity    = (*customAPIDestinationResource)(nil)
-	_ resource.ResourceWithImportState = (*customAPIDestinationResource)(nil)
-	_ resource.ResourceWithMoveState   = (*customAPIDestinationResource)(nil)
+	_ resource.Resource                   = (*customAPIDestinationResource)(nil)
+	_ resource.ResourceWithConfigure      = (*customAPIDestinationResource)(nil)
+	_ resource.ResourceWithIdentity       = (*customAPIDestinationResource)(nil)
+	_ resource.ResourceWithImportState    = (*customAPIDestinationResource)(nil)
+	_ resource.ResourceWithModifyPlan     = (*customAPIDestinationResource)(nil)
+	_ resource.ResourceWithMoveState      = (*customAPIDestinationResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*customAPIDestinationResource)(nil)
 )
 
 //nolint:ireturn
@@ -44,6 +46,48 @@ func (r *customAPIDestinationResource) Configure(_ context.Context, req resource
 
 func (r *customAPIDestinationResource) IdentitySchema(ctx context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
 	resp.IdentitySchema = CustomAPIDestinationResourceIdentitySchema(ctx)
+}
+
+func (r *customAPIDestinationResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config CustomAPIDestinationModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(hydrateCustomAPIHeaderWriteOnlyValues(ctx, req.Config, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	credentials := config.Credentials.Value()
+	if credentials.CustomHeaders.IsNull() || credentials.CustomHeaders.IsUnknown() {
+		return
+	}
+
+	for key, header := range credentials.CustomHeaders.Elements() {
+		headerValue := header.Value()
+		validateRequiredStringCredential(&resp.Diagnostics, headerValue.Value, headerValue.ValueWO, customAPIHeaderValuePath(key), customAPIHeaderValueWOPath(key))
+	}
+}
+
+func (r *customAPIDestinationResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, config CustomAPIDestinationModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(hydrateCustomAPIHeaderWriteOnlyValues(ctx, req.Config, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, values, modelDiags := customAPIDestinationModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	markWriteOnlyCredentialChange(ctx, req, resp, values, NewTypedObjectUnknown[CustomAPIDestinationConnectionDetails]())
 }
 
 func (r *customAPIDestinationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -116,9 +160,9 @@ func (r *customAPIDestinationResource) MoveState(ctx context.Context) []resource
 					}
 
 					if destinationConnectionDetails.CustomHeaders != nil {
-						customAPIDestinationConnectionDetailsCustomHeaders := make(map[string]TypedObject[CustomAPIDestinationCustomHeader], 0)
+						customAPIDestinationConnectionDetailsCustomHeaders := make(map[string]TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader], 0)
 						for key, value := range destinationConnectionDetails.CustomHeaders {
-							customAPIDestinationConnectionDetailsCustomHeaders[key] = NewTypedObject(CustomAPIDestinationCustomHeader{
+							customAPIDestinationConnectionDetailsCustomHeaders[key] = NewTypedObject(CustomAPIDestinationConnectionDetailsCustomHeader{
 								Value:    types.StringPointerValue(value.Value),
 								IsSecret: types.BoolPointerValue(value.IsSecret),
 							})
@@ -142,17 +186,26 @@ func (r *customAPIDestinationResource) MoveState(ctx context.Context) []resource
 	}
 }
 
-//nolint:dupl
 func (r *customAPIDestinationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var plan CustomAPIDestinationModel
+	var plan, config CustomAPIDestinationModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(hydrateCustomAPIHeaderWriteOnlyValues(ctx, req.Config, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	createDestinationRequest, createDestinationRequestDiags := plan.ToCreateDestinationData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := customAPIDestinationModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createDestinationRequest, createDestinationRequestDiags := requestModel.ToCreateDestinationData(ctx)
 	resp.Diagnostics.Append(createDestinationRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -162,9 +215,7 @@ func (r *customAPIDestinationResource) Create(ctx context.Context, req resource.
 	createDestinationResponse, createDestinationErr := r.providerData.client.CreateDestination(ctx, &createDestinationRequest)
 
 	tflog.Info(ctx, "destination.create", map[string]any{
-		"request":  createDestinationRequest,
-		"response": createDestinationResponse,
-		"err":      createDestinationErr,
+		"err": createDestinationErr,
 	})
 
 	if createDestinationResponse == nil {
@@ -189,18 +240,20 @@ func (r *customAPIDestinationResource) Create(ctx context.Context, req resource.
 	getDestinationResponse, getDestinationErr := r.providerData.client.GetDestination(ctx, getDestinationParams)
 
 	tflog.Info(ctx, "destination.read", map[string]any{
-		"request":  getDestinationParams,
-		"response": getDestinationResponse,
-		"err":      getDestinationErr,
+		"request": getDestinationParams,
+		"err":     getDestinationErr,
 	})
+
+	if getDestinationResponse == nil {
+		resp.Diagnostics.AddError("Failed to read destination after create", detailFromError(getDestinationErr))
+
+		return
+	}
 
 	model, modelDiags := NewCustomAPIDestinationModelFromResponse(ctx, getDestinationResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedCustomAPIDestinationCredentials(model, plan, config, model.ConnectionDetails.Value(), writeOnlyValues)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -208,6 +261,7 @@ func (r *customAPIDestinationResource) Create(ctx context.Context, req resource.
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 func (r *customAPIDestinationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -226,9 +280,8 @@ func (r *customAPIDestinationResource) Read(ctx context.Context, req resource.Re
 	getDestinationResponse, getDestinationErr := r.providerData.client.GetDestination(ctx, params)
 
 	tflog.Info(ctx, "destination.read", map[string]any{
-		"params":   params,
-		"response": getDestinationResponse,
-		"err":      getDestinationErr,
+		"params": params,
+		"err":    getDestinationErr,
 	})
 
 	if getDestinationResponse == nil {
@@ -250,10 +303,12 @@ func (r *customAPIDestinationResource) Read(ctx context.Context, req resource.Re
 	model, modelDiags := NewCustomAPIDestinationModelFromResponse(ctx, getDestinationResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
 
+	connectionDetails := sanitizedCustomAPIConnectionDetails(model.ConnectionDetails.Value(), state.Credentials.Value().CustomHeaders, nil)
 	credentials := state.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
+	credentials.UpdateWithConnectionDetails(connectionDetails)
 
 	model.Credentials = NewTypedObject(credentials)
+	model.ConnectionDetails = NewTypedObject(connectionDetails)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -264,10 +319,12 @@ func (r *customAPIDestinationResource) Read(ctx context.Context, req resource.Re
 }
 
 func (r *customAPIDestinationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state, plan CustomAPIDestinationModel
+	var state, plan, config CustomAPIDestinationModel
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(hydrateCustomAPIHeaderWriteOnlyValues(ctx, req.Config, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -277,7 +334,15 @@ func (r *customAPIDestinationResource) Update(ctx context.Context, req resource.
 		DestinationID: plan.ID.ValueString(),
 	}
 
-	updateDestinationRequest, updateDestinationRequestDiags := plan.ToUpdateDestinationData(ctx)
+	requestModel, writeOnlyValues, requestModelDiags := customAPIDestinationModelWithWriteOnlyCredentials(plan, config)
+	resp.Diagnostics.Append(requestModelDiags...)
+	resp.Diagnostics.Append(validateWriteOnlyCredentialValuesKnown(writeOnlyValues)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateDestinationRequest, updateDestinationRequestDiags := requestModel.ToUpdateDestinationData(ctx)
 	resp.Diagnostics.Append(updateDestinationRequestDiags...)
 
 	if resp.Diagnostics.HasError() {
@@ -287,10 +352,8 @@ func (r *customAPIDestinationResource) Update(ctx context.Context, req resource.
 	updateDestinationResponse, updateDestinationErr := r.providerData.client.UpdateDestination(ctx, &updateDestinationRequest, params)
 
 	tflog.Info(ctx, "destination.update", map[string]any{
-		"params":   params,
-		"request":  updateDestinationRequest,
-		"response": updateDestinationResponse,
-		"err":      updateDestinationErr,
+		"params": params,
+		"err":    updateDestinationErr,
 	})
 
 	if updateDestinationResponse == nil {
@@ -302,13 +365,11 @@ func (r *customAPIDestinationResource) Update(ctx context.Context, req resource.
 	model, modelDiags := NewCustomAPIDestinationModelFromResponse(ctx, updateDestinationResponse.Response.Data)
 	resp.Diagnostics.Append(modelDiags...)
 
-	credentials := plan.Credentials.Value()
-	credentials.UpdateWithConnectionDetails(model.ConnectionDetails.Value())
-
-	model.Credentials = NewTypedObject(credentials)
+	model = sanitizedCustomAPIDestinationCredentials(model, plan, config, model.ConnectionDetails.Value(), writeOnlyValues)
 
 	resp.Diagnostics.Append(resp.Identity.SetAttribute(ctx, path.Root("id"), model.ID)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(writeWriteOnlyCredentialVerifiers(ctx, resp.Private, writeOnlyValues)...)
 }
 
 //nolint:dupl
@@ -328,9 +389,8 @@ func (r *customAPIDestinationResource) Delete(ctx context.Context, req resource.
 	deleteDestinationResponse, deleteDestinationErr := r.providerData.client.DeleteDestination(ctx, params)
 
 	tflog.Info(ctx, "destination.delete", map[string]any{
-		"params":   params,
-		"response": deleteDestinationResponse,
-		"err":      deleteDestinationErr,
+		"params": params,
+		"err":    deleteDestinationErr,
 	})
 
 	var srsc *cm.StatusResponseStatusCode

--- a/internal/provider/custom_api_destination_resource_schema.go
+++ b/internal/provider/custom_api_destination_resource_schema.go
@@ -67,8 +67,14 @@ func CustomAPIDestinationCredentialsResourceSchemaAttributes(ctx context.Context
 func CustomAPIDestinationCredentialsCustomHeaderResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"value": schema.StringAttribute{
-			Required:            true,
-			MarkdownDescription: "HTTP header value sent to the Custom API webhook.",
+			Optional:            true,
+			MarkdownDescription: "HTTP header value sent to the Custom API webhook. Configure exactly one of `value` or `value_wo` for each header.",
+		},
+		"value_wo": schema.StringAttribute{
+			Optional:            true,
+			Sensitive:           true,
+			WriteOnly:           true,
+			MarkdownDescription: "HTTP header value sent to the Custom API webhook. Configure exactly one of `value` or `value_wo` for each header.",
 		},
 		"is_secret": schema.BoolAttribute{
 			Optional:            true,
@@ -104,9 +110,9 @@ func CustomAPIDestinationConnectionDetailsResourceSchemaAttributes(ctx context.C
 			MarkdownDescription: "Additional HTTP headers Census has stored for this Custom API webhook.",
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: CustomAPIDestinationConnectionDetailsCustomHeaderResourceSchemaAttributes(ctx),
-				CustomType: NewTypedObjectNull[CustomAPIDestinationCustomHeader]().CustomType(ctx),
+				CustomType: NewTypedObjectNull[CustomAPIDestinationConnectionDetailsCustomHeader]().CustomType(ctx),
 			},
-			CustomType: NewTypedMapNull[TypedObject[CustomAPIDestinationCustomHeader]]().CustomType(ctx),
+			CustomType: NewTypedMapNull[TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]]().CustomType(ctx),
 		},
 	}
 }

--- a/internal/provider/custom_api_destination_resource_test.go
+++ b/internal/provider/custom_api_destination_resource_test.go
@@ -139,6 +139,191 @@ func TestAccCustomAPIDestinationResourceCreateUpdateDelete(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest
+func TestAccCustomAPIDestinationResourceWriteOnlyHeaders(t *testing.T) {
+	server, err := cmt.NewCensusManagementServer()
+	require.NoError(t, err)
+
+	ProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "censusworkspace_custom_api_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    api_version = 1
+    webhook_url = "https://example.org/census-destination"
+    custom_headers = {
+      "x-client-id" = {
+        value     = "client-123"
+        is_secret = false
+      }
+      "x-\"secret\"\\key" = {
+        value     = "secret"
+        is_secret = true
+      }
+    }
+  }
+}
+`,
+			},
+			{
+				Config: `
+resource "censusworkspace_custom_api_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    api_version = 1
+    webhook_url = "https://example.org/census-destination"
+    custom_headers = {
+      "x-client-id" = {
+        value     = "client-123"
+        is_secret = false
+      }
+      "x-\"secret\"\\key" = {
+        value_wo  = "secret"
+        is_secret = true
+      }
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_custom_api_destination.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers").AtMapKey(`x-"secret"\key`).AtMapKey("value"), knownvalue.Null()),
+						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers").AtMapKey("x-client-id").AtMapKey("value"), knownvalue.StringExact("client-123")),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_custom_api_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    api_version = 1
+    webhook_url = "https://example.org/census-destination"
+    custom_headers = {
+      "x-client-id" = {
+        value     = "client-123"
+        is_secret = false
+      }
+      "x-\"secret\"\\key" = {
+        value_wo  = "rotated-secret"
+        is_secret = true
+      }
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_custom_api_destination.test", plancheck.ResourceActionUpdate),
+						plancheck.ExpectUnknownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("connection_details")),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers").AtMapKey(`x-"secret"\key`).AtMapKey("value"), knownvalue.Null()),
+						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers").AtMapKey("x-client-id").AtMapKey("value"), knownvalue.StringExact("client-123")),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_custom_api_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    api_version = 1
+    webhook_url = "https://example.org/census-destination"
+    custom_headers = {
+      "x-client-id" = {
+        value     = "client-123"
+        is_secret = false
+      }
+      "x-\"secret\"\\key" = {
+        value_wo  = "rotated-secret"
+        is_secret = true
+      }
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectResourceAction("censusworkspace_custom_api_destination.test", plancheck.ResourceActionNoop),
+					},
+				},
+			},
+			{
+				Config: `
+resource "censusworkspace_custom_api_destination" "test" {
+  name = "Test Destination (updated)"
+
+  credentials = {
+    api_version = 1
+    webhook_url = "https://example.org/census-destination"
+    custom_headers = {
+      "x-client-id" = {
+        value     = "client-123"
+        is_secret = false
+      }
+      "x-\"secret\"\\key" = {
+        value_wo  = "rotated-secret"
+        is_secret = true
+      }
+    }
+  }
+}
+`,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("censusworkspace_custom_api_destination.test", plancheck.ResourceActionUpdate),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Destination (updated)")),
+						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers").AtMapKey(`x-"secret"\key`).AtMapKey("value"), knownvalue.Null()),
+						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers").AtMapKey("x-client-id").AtMapKey("value"), knownvalue.StringExact("client-123")),
+					},
+				},
+			},
+		},
+	})
+}
+
+//nolint:paralleltest
+func TestAccCustomAPIDestinationResourceMissingHeaderValue(t *testing.T) {
+	server, err := cmt.NewCensusManagementServer()
+	require.NoError(t, err)
+
+	ProviderMockedResourceTest(t, server, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "censusworkspace_custom_api_destination" "test" {
+  name = "Test Destination"
+
+  credentials = {
+    api_version = 1
+    webhook_url = "https://example.org/census-destination"
+    custom_headers = {
+      "x-client-secret" = {
+        is_secret = true
+      }
+    }
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`One of credentials\.custom_headers\["x-client-secret"\]\.value or\s+credentials\.custom_headers\["x-client-secret"\]\.value_wo must be configured`),
+			},
+		},
+	})
+}
+
 //nolint:dupl,paralleltest
 func TestAccCustomAPIDestinationResourceMovedFromDestination(t *testing.T) {
 	server, err := cmt.NewCensusManagementServer()

--- a/internal/provider/source_resource_test.go
+++ b/internal/provider/source_resource_test.go
@@ -268,6 +268,7 @@ func TestProtocol6BigQuerySourceResourceReadAcceptsExistingLabelState(t *testing
 		"project_id":     tftypes.String,
 		"private_key_id": tftypes.String,
 		"private_key":    tftypes.String,
+		"private_key_wo": tftypes.String,
 		"client_id":      tftypes.String,
 		"client_email":   tftypes.String,
 	}}

--- a/internal/provider/write_only_credentials.go
+++ b/internal/provider/write_only_credentials.go
@@ -1,0 +1,465 @@
+package provider
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"golang.org/x/crypto/argon2"
+)
+
+const (
+	writeOnlyCredentialVerifiersPrivateKey = "write_only_credential_verifiers"
+
+	writeOnlyCredentialArgon2IDMemory      = 16 * 1024
+	writeOnlyCredentialArgon2IDTime        = 1
+	writeOnlyCredentialArgon2IDParallelism = 1
+	writeOnlyCredentialSaltLength          = 16
+	writeOnlyCredentialKeyLength           = 32
+	writeOnlyCredentialParameterPartCount  = 3
+)
+
+type privateStateReader interface {
+	GetKey(ctx context.Context, key string) ([]byte, diag.Diagnostics)
+}
+
+type privateStateWriter interface {
+	SetKey(ctx context.Context, key string, value []byte) diag.Diagnostics
+}
+
+func writeOnlyStringConfigured(value types.String) bool {
+	return !value.IsNull()
+}
+
+func stringKnown(value types.String) bool {
+	return !value.IsNull() && !value.IsUnknown()
+}
+
+func validateStringCredential(diags *diag.Diagnostics, legacy, writeOnly types.String, legacyPath, writeOnlyPath path.Path) {
+	_, _, credentialDiags := resolveStringCredential(legacy, writeOnly, legacyPath, writeOnlyPath, false)
+	diags.Append(credentialDiags...)
+}
+
+func validateRequiredStringCredential(diags *diag.Diagnostics, legacy, writeOnly types.String, legacyPath, writeOnlyPath path.Path) {
+	_, _, credentialDiags := resolveStringCredential(legacy, writeOnly, legacyPath, writeOnlyPath, true)
+	diags.Append(credentialDiags...)
+}
+
+func resolveStringCredential(legacy, writeOnly types.String, legacyPath, writeOnlyPath path.Path, required bool) (types.String, bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	legacyConfigured := stringKnown(legacy)
+	writeOnlyConfigured := writeOnlyStringConfigured(writeOnly)
+
+	if legacyConfigured && writeOnlyConfigured {
+		diags.AddError(
+			"Conflicting credential arguments",
+			"Only one of "+legacyPath.String()+" and "+writeOnlyPath.String()+" can be configured.",
+		)
+
+		return types.StringNull(), false, diags
+	}
+
+	if writeOnlyConfigured {
+		return writeOnly, true, diags
+	}
+
+	if legacyConfigured {
+		return legacy, false, diags
+	}
+
+	if legacy.IsUnknown() || writeOnly.IsUnknown() {
+		return types.StringNull(), false, diags
+	}
+
+	if required {
+		diags.AddError(
+			"Missing credential argument",
+			"One of "+legacyPath.String()+" or "+writeOnlyPath.String()+" must be configured.",
+		)
+	}
+
+	return types.StringNull(), false, diags
+}
+
+type writeOnlyCredentialPath string
+
+type writeOnlyCredentialPathSegment struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+func writeOnlyCredentialPathFromPath(argumentPath path.Path) (writeOnlyCredentialPath, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	segments := make([]writeOnlyCredentialPathSegment, 0, len(argumentPath.Steps()))
+	for _, step := range argumentPath.Steps() {
+		switch step := step.(type) {
+		case path.PathStepAttributeName:
+			segments = append(segments, writeOnlyCredentialPathSegment{
+				Type:  "attribute",
+				Value: string(step),
+			})
+		case path.PathStepElementKeyString:
+			segments = append(segments, writeOnlyCredentialPathSegment{
+				Type:  "map_key",
+				Value: string(step),
+			})
+		default:
+			diags.AddError(
+				"Unsupported write-only credential path",
+				fmt.Sprintf("Write-only credential path %s uses unsupported path step type %T.", argumentPath.String(), step),
+			)
+
+			return "", diags
+		}
+	}
+
+	data, err := json.Marshal(segments)
+	if err != nil {
+		diags.AddError("Invalid write-only credential path", err.Error())
+
+		return "", diags
+	}
+
+	return writeOnlyCredentialPath(data), diags
+}
+
+type writeOnlyCredentialValues map[writeOnlyCredentialPath]types.String
+
+func (v writeOnlyCredentialValues) Add(argumentPath path.Path, value types.String) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if value.IsNull() {
+		return diags
+	}
+
+	key, pathDiags := writeOnlyCredentialPathFromPath(argumentPath)
+	diags.Append(pathDiags...)
+
+	if diags.HasError() {
+		return diags
+	}
+
+	v[key] = value
+
+	return diags
+}
+
+func (v writeOnlyCredentialValues) Configured(argumentPath path.Path) (bool, diag.Diagnostics) {
+	key, diags := writeOnlyCredentialPathFromPath(argumentPath)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	_, ok := v[key]
+
+	return ok, diags
+}
+
+func (v writeOnlyCredentialValues) Known(argumentPath path.Path) (types.String, bool, diag.Diagnostics) {
+	key, diags := writeOnlyCredentialPathFromPath(argumentPath)
+	if diags.HasError() {
+		return types.StringNull(), false, diags
+	}
+
+	value, ok := v[key]
+	if !ok || value.IsNull() || value.IsUnknown() {
+		return types.StringNull(), false, diags
+	}
+
+	return value, true, diags
+}
+
+func writeOnlyCredentialPreimage(argumentPath writeOnlyCredentialPath, value types.String) []byte {
+	return []byte(string(argumentPath) + "\x00" + value.ValueString())
+}
+
+func writeOnlyCredentialVerifier(argumentPath writeOnlyCredentialPath, value types.String) (string, error) {
+	salt := make([]byte, writeOnlyCredentialSaltLength)
+
+	_, err := rand.Read(salt)
+	if err != nil {
+		return "", fmt.Errorf("generate write-only credential verifier salt: %w", err)
+	}
+
+	key := argon2.IDKey(
+		writeOnlyCredentialPreimage(argumentPath, value),
+		salt,
+		writeOnlyCredentialArgon2IDTime,
+		writeOnlyCredentialArgon2IDMemory,
+		writeOnlyCredentialArgon2IDParallelism,
+		writeOnlyCredentialKeyLength,
+	)
+
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		writeOnlyCredentialArgon2IDMemory,
+		writeOnlyCredentialArgon2IDTime,
+		writeOnlyCredentialArgon2IDParallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(key),
+	), nil
+}
+
+func writeOnlyCredentialVerifierMatches(argumentPath writeOnlyCredentialPath, value types.String, verifier string) bool { //nolint:cyclop
+	if value.IsNull() || value.IsUnknown() {
+		return false
+	}
+
+	parts := strings.Split(verifier, "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return false
+	}
+
+	version, hasVersion := strings.CutPrefix(parts[2], "v=")
+	if !hasVersion {
+		return false
+	}
+
+	parsedVersion, err := strconv.Atoi(version)
+	if err != nil || parsedVersion != argon2.Version {
+		return false
+	}
+
+	parameters, hasMemoryParameter := strings.CutPrefix(parts[3], "m=")
+	if !hasMemoryParameter {
+		return false
+	}
+
+	parameterParts := strings.Split(parameters, ",")
+	if len(parameterParts) != writeOnlyCredentialParameterPartCount {
+		return false
+	}
+
+	memory, err := strconv.ParseUint(parameterParts[0], 10, 32)
+	if err != nil {
+		return false
+	}
+
+	timePart, hasTimeParameter := strings.CutPrefix(parameterParts[1], "t=")
+	if !hasTimeParameter {
+		return false
+	}
+
+	time, err := strconv.ParseUint(timePart, 10, 32)
+	if err != nil {
+		return false
+	}
+
+	parallelismPart, hasParallelismParameter := strings.CutPrefix(parameterParts[2], "p=")
+	if !hasParallelismParameter {
+		return false
+	}
+
+	parallelism, err := strconv.ParseUint(parallelismPart, 10, 8)
+	if err != nil {
+		return false
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false
+	}
+
+	if memory != writeOnlyCredentialArgon2IDMemory ||
+		time != writeOnlyCredentialArgon2IDTime ||
+		parallelism != writeOnlyCredentialArgon2IDParallelism ||
+		len(salt) != writeOnlyCredentialSaltLength {
+		return false
+	}
+
+	expectedKey, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false
+	}
+
+	if len(expectedKey) != writeOnlyCredentialKeyLength {
+		return false
+	}
+
+	actualKey := argon2.IDKey(
+		writeOnlyCredentialPreimage(argumentPath, value),
+		salt,
+		uint32(time),
+		uint32(memory),
+		uint8(parallelism),
+		writeOnlyCredentialKeyLength,
+	)
+
+	return subtle.ConstantTimeCompare(actualKey, expectedKey) == 1
+}
+
+func readWriteOnlyCredentialVerifiers(ctx context.Context, private privateStateReader) (map[string]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if private == nil {
+		return map[string]string{}, diags
+	}
+
+	data, getDiags := private.GetKey(ctx, writeOnlyCredentialVerifiersPrivateKey)
+	diags.Append(getDiags...)
+
+	if diags.HasError() || len(data) == 0 {
+		return map[string]string{}, diags
+	}
+
+	verifiers := map[string]string{}
+
+	err := json.Unmarshal(data, &verifiers)
+	if err != nil {
+		diags.AddError("Invalid write-only credential verifier private state", err.Error())
+
+		return map[string]string{}, diags
+	}
+
+	return verifiers, diags
+}
+
+func writeWriteOnlyCredentialVerifiers(ctx context.Context, private privateStateWriter, values writeOnlyCredentialValues) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if private == nil {
+		return diags
+	}
+
+	if len(values) == 0 {
+		diags.Append(private.SetKey(ctx, writeOnlyCredentialVerifiersPrivateKey, nil)...)
+
+		return diags
+	}
+
+	diags.Append(validateWriteOnlyCredentialValuesKnown(values)...)
+
+	if diags.HasError() {
+		return diags
+	}
+
+	verifiers := make(map[string]string, len(values))
+	for argumentPath, value := range values {
+		verifier, err := writeOnlyCredentialVerifier(argumentPath, value)
+		if err != nil {
+			diags.AddError("Failed to create write-only credential verifier", err.Error())
+
+			return diags
+		}
+
+		verifiers[string(argumentPath)] = verifier
+	}
+
+	data, err := json.Marshal(verifiers)
+	if err != nil {
+		diags.AddError("Invalid write-only credential verifiers", err.Error())
+
+		return diags
+	}
+
+	diags.Append(private.SetKey(ctx, writeOnlyCredentialVerifiersPrivateKey, data)...)
+
+	return diags
+}
+
+func validateWriteOnlyCredentialValuesKnown(values writeOnlyCredentialValues) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	for argumentPath, value := range values {
+		if value.IsUnknown() {
+			diags.AddError(
+				"Unknown write-only credential value",
+				"Write-only credential "+string(argumentPath)+" is configured but still unknown during apply.",
+			)
+
+			continue
+		}
+
+		if value.IsNull() {
+			diags.AddError(
+				"Invalid write-only credential value",
+				"Write-only credential "+string(argumentPath)+" was tracked as configured with a null value.",
+			)
+		}
+	}
+
+	return diags
+}
+
+func writeOnlyCredentialVerifiersChanged(ctx context.Context, private privateStateReader, configured writeOnlyCredentialValues) (bool, diag.Diagnostics) {
+	stored, diags := readWriteOnlyCredentialVerifiers(ctx, private)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	if len(stored) != len(configured) {
+		return true, diags
+	}
+
+	for argumentPath, value := range configured {
+		if value.IsUnknown() {
+			return true, diags
+		}
+
+		if value.IsNull() {
+			continue
+		}
+
+		if !writeOnlyCredentialVerifierMatches(argumentPath, value, stored[string(argumentPath)]) {
+			return true, diags
+		}
+	}
+
+	return false, diags
+}
+
+func markWriteOnlyCredentialChange(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse, values writeOnlyCredentialValues, connectionDetails attr.Value) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	changed, verifierDiags := writeOnlyCredentialVerifiersChanged(ctx, req.Private, values)
+	resp.Diagnostics.Append(verifierDiags...)
+
+	if resp.Diagnostics.HasError() || !changed {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("connection_details"), connectionDetails)...)
+}
+
+type writeOnlyCredentialModelResolver[T any] func(plan, config T) (T, writeOnlyCredentialValues, diag.Diagnostics)
+
+func modifyPlanForWriteOnlyCredentialChange[T any](
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+	resolver writeOnlyCredentialModelResolver[T],
+	connectionDetails attr.Value,
+) {
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, config T
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, values, modelDiags := resolver(plan, config)
+	resp.Diagnostics.Append(modelDiags...)
+
+	markWriteOnlyCredentialChange(ctx, req, resp, values, connectionDetails)
+}

--- a/internal/provider/write_only_credentials_test.go
+++ b/internal/provider/write_only_credentials_test.go
@@ -1,0 +1,533 @@
+package provider //nolint:testpackage
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrazeDestinationWriteOnlyCredentialResolver(t *testing.T) {
+	t.Parallel()
+
+	plan := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKey:      types.StringNull(),
+			ClientKey:   types.StringValue("client-key"),
+		}),
+	}
+	config := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			APIKeyWO: types.StringValue("api-key"),
+		}),
+	}
+
+	requestModel, values, diags := brazeDestinationModelWithWriteOnlyCredentials(plan, config)
+	require.False(t, diags.HasError(), diags)
+	assert.Contains(t, values, mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("api_key_wo")))
+	assert.Equal(t, "api-key", requestModel.Credentials.Value().APIKey.ValueString())
+	assert.Equal(t, "client-key", requestModel.Credentials.Value().ClientKey.ValueString())
+
+	stateModel := sanitizedBrazeDestinationCredentials(plan, plan, config, BrazeDestinationConnectionDetails{
+		InstanceURL: types.StringValue("normalized-instance-url"),
+	})
+	assert.True(t, stateModel.Credentials.Value().APIKey.IsNull())
+	assert.Equal(t, "client-key", stateModel.Credentials.Value().ClientKey.ValueString())
+	assert.Equal(t, "normalized-instance-url", stateModel.Credentials.Value().InstanceURL.ValueString())
+}
+
+func TestBrazeDestinationWriteOnlyCredentialResolverUsesPlanWhenConfigCredentialsUnknown(t *testing.T) {
+	t.Parallel()
+
+	plan := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKey:      types.StringValue("api-key"),
+			ClientKey:   types.StringValue("client-key"),
+		}),
+	}
+	config := BrazeDestinationModel{
+		Credentials: NewTypedObjectUnknown[BrazeDestinationCredentials](),
+	}
+
+	requestModel, values, diags := brazeDestinationModelWithWriteOnlyCredentials(plan, config)
+	require.False(t, diags.HasError(), diags)
+	assert.Empty(t, values)
+	assert.Equal(t, "instance-url", requestModel.Credentials.Value().InstanceURL.ValueString())
+	assert.Equal(t, "api-key", requestModel.Credentials.Value().APIKey.ValueString())
+	assert.Equal(t, "client-key", requestModel.Credentials.Value().ClientKey.ValueString())
+}
+
+func TestBrazeDestinationWriteOnlyCredentialResolverTracksUnknownWriteOnlyValue(t *testing.T) {
+	t.Parallel()
+
+	writeOnlyPath := path.Root("credentials").AtName("api_key_wo")
+	plan := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKey:      types.StringNull(),
+		}),
+	}
+	config := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKeyWO:    types.StringUnknown(),
+		}),
+	}
+
+	_, values, diags := brazeDestinationModelWithWriteOnlyCredentials(plan, config)
+
+	require.False(t, diags.HasError(), diags)
+	writeOnlyKey := mustWriteOnlyCredentialPath(t, writeOnlyPath)
+	require.Contains(t, values, writeOnlyKey)
+	assert.True(t, values[writeOnlyKey].IsUnknown())
+}
+
+func TestBrazeDestinationWriteOnlyCredentialResolverRejectsUnknownWriteOnlyValueForApply(t *testing.T) {
+	t.Parallel()
+
+	plan := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKey:      types.StringNull(),
+		}),
+	}
+	config := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKeyWO:    types.StringUnknown(),
+		}),
+	}
+
+	requestModel, values, diags := brazeDestinationModelWithWriteOnlyCredentials(plan, config)
+	require.False(t, diags.HasError(), diags)
+	assert.True(t, requestModel.Credentials.Value().APIKey.IsUnknown())
+
+	diags = validateWriteOnlyCredentialValuesKnown(values)
+	assert.True(t, diags.HasError())
+}
+
+func TestSanitizedBrazeDestinationCredentialsTreatsUnknownWriteOnlyValueAsConfigured(t *testing.T) {
+	t.Parallel()
+
+	plan := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKey:      types.StringUnknown(),
+			ClientKey:   types.StringValue("client-key"),
+		}),
+	}
+	config := BrazeDestinationModel{
+		Credentials: NewTypedObject(BrazeDestinationCredentials{
+			InstanceURL: types.StringValue("instance-url"),
+			APIKeyWO:    types.StringUnknown(),
+		}),
+	}
+
+	stateModel := sanitizedBrazeDestinationCredentials(plan, plan, config, BrazeDestinationConnectionDetails{
+		InstanceURL: types.StringValue("normalized-instance-url"),
+	})
+
+	assert.True(t, stateModel.Credentials.Value().APIKey.IsNull())
+	assert.Equal(t, "client-key", stateModel.Credentials.Value().ClientKey.ValueString())
+	assert.Equal(t, "normalized-instance-url", stateModel.Credentials.Value().InstanceURL.ValueString())
+}
+
+func TestCustomAPIDestinationWriteOnlyHeaderResolverKeepsIsSecretOrthogonal(t *testing.T) {
+	t.Parallel()
+
+	plan := CustomAPIDestinationModel{
+		Credentials: NewTypedObject(CustomAPIDestinationCredentials{
+			CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationCustomHeader]{
+				"x-client-id": NewTypedObject(CustomAPIDestinationCustomHeader{
+					Value:    types.StringValue("client-id"),
+					IsSecret: types.BoolValue(false),
+				}),
+				"x-client-secret": NewTypedObject(CustomAPIDestinationCustomHeader{
+					Value:    types.StringNull(),
+					IsSecret: types.BoolValue(true),
+				}),
+			}),
+		}),
+	}
+	config := CustomAPIDestinationModel{
+		Credentials: NewTypedObject(CustomAPIDestinationCredentials{
+			CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationCustomHeader]{
+				"x-client-secret": NewTypedObject(CustomAPIDestinationCustomHeader{
+					ValueWO:  types.StringValue("secret"),
+					IsSecret: types.BoolValue(true),
+				}),
+			}),
+		}),
+	}
+
+	requestModel, values, diags := customAPIDestinationModelWithWriteOnlyCredentials(plan, config)
+	require.False(t, diags.HasError(), diags)
+	assert.Contains(t, values, mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("custom_headers").AtMapKey("x-client-secret").AtName("value_wo")))
+
+	headers := requestModel.Credentials.Value().CustomHeaders.Elements()
+	assert.Equal(t, "client-id", headers["x-client-id"].Value().Value.ValueString())
+	assert.False(t, headers["x-client-id"].Value().IsSecret.ValueBool())
+	assert.Equal(t, "secret", headers["x-client-secret"].Value().Value.ValueString())
+	assert.True(t, headers["x-client-secret"].Value().IsSecret.ValueBool())
+
+	stateModel := sanitizedCustomAPIDestinationCredentials(
+		plan,
+		plan,
+		config,
+		CustomAPIDestinationConnectionDetails{
+			CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationConnectionDetailsCustomHeader]{
+				"x-client-id": NewTypedObject(CustomAPIDestinationConnectionDetailsCustomHeader{
+					Value:    types.StringValue("client-id"),
+					IsSecret: types.BoolValue(false),
+				}),
+				"x-client-secret": NewTypedObject(CustomAPIDestinationConnectionDetailsCustomHeader{
+					Value:    types.StringNull(),
+					IsSecret: types.BoolValue(true),
+				}),
+			}),
+		},
+		values,
+	)
+	stateHeaders := stateModel.Credentials.Value().CustomHeaders.Elements()
+	assert.True(t, stateHeaders["x-client-secret"].Value().Value.IsNull())
+	assert.True(t, stateHeaders["x-client-secret"].Value().IsSecret.ValueBool())
+}
+
+func TestWriteOnlyCredentialVerifierIncludesCanonicalPath(t *testing.T) {
+	t.Parallel()
+
+	value := types.StringValue("shared-secret")
+	apiKeyPath := path.Root("credentials").AtName("api_key_wo")
+	clientKeyPath := path.Root("credentials").AtName("client_key_wo")
+	apiKeyKey := mustWriteOnlyCredentialPath(t, apiKeyPath)
+	clientKeyKey := mustWriteOnlyCredentialPath(t, clientKeyPath)
+	apiKeyVerifier, err := writeOnlyCredentialVerifier(apiKeyKey, value)
+	require.NoError(t, err)
+
+	assert.True(t, writeOnlyCredentialVerifierMatches(apiKeyKey, value, apiKeyVerifier))
+	assert.False(t, writeOnlyCredentialVerifierMatches(clientKeyKey, value, apiKeyVerifier))
+}
+
+func TestResolveRequiredStringCredentialAllowsUnknownValues(t *testing.T) {
+	t.Parallel()
+
+	_, _, diags := resolveStringCredential(
+		types.StringUnknown(),
+		types.StringNull(),
+		path.Root("credentials").AtName("api_key"),
+		path.Root("credentials").AtName("api_key_wo"),
+		true,
+	)
+
+	assert.False(t, diags.HasError(), diags)
+}
+
+func TestResolveRequiredStringCredentialRejectsMissingValues(t *testing.T) {
+	t.Parallel()
+
+	_, _, diags := resolveStringCredential(
+		types.StringNull(),
+		types.StringNull(),
+		path.Root("credentials").AtName("api_key"),
+		path.Root("credentials").AtName("api_key_wo"),
+		true,
+	)
+
+	assert.True(t, diags.HasError())
+}
+
+func TestWriteOnlyCredentialVerifierRejectsUnexpectedParameters(t *testing.T) {
+	t.Parallel()
+
+	value := types.StringValue("shared-secret")
+	apiKeyPath := path.Root("credentials").AtName("api_key_wo")
+	apiKeyKey := mustWriteOnlyCredentialPath(t, apiKeyPath)
+	verifier := mustWriteOnlyCredentialVerifier(t, apiKeyPath, value)
+
+	assert.False(t, writeOnlyCredentialVerifierMatches(apiKeyKey, value, strings.Replace(verifier, "m=16384,t=1,p=1", "m=32768,t=1,p=1", 1)))
+	assert.False(t, writeOnlyCredentialVerifierMatches(apiKeyKey, value, strings.Replace(verifier, "m=16384,t=1,p=1", "m=16384,t=2,p=1", 1)))
+	assert.False(t, writeOnlyCredentialVerifierMatches(apiKeyKey, value, strings.Replace(verifier, "m=16384,t=1,p=1", "m=16384,t=1,p=2", 1)))
+
+	parts := strings.Split(verifier, "$")
+	require.Len(t, parts, 6)
+	parts[4] = base64.RawStdEncoding.EncodeToString(make([]byte, writeOnlyCredentialSaltLength+1))
+	assert.False(t, writeOnlyCredentialVerifierMatches(apiKeyKey, value, strings.Join(parts, "$")))
+}
+
+func TestWriteOnlyCredentialPathEncodesAttributePath(t *testing.T) {
+	t.Parallel()
+
+	key := mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("api_key_wo"))
+
+	assert.JSONEq(t, `[{"type":"attribute","value":"credentials"},{"type":"attribute","value":"api_key_wo"}]`, string(key))
+}
+
+func TestWriteOnlyCredentialPathEncodesMapKeyPath(t *testing.T) {
+	t.Parallel()
+
+	key := mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("custom_headers").AtMapKey("x-client-secret").AtName("value_wo"))
+
+	assert.JSONEq(t, `[{"type":"attribute","value":"credentials"},{"type":"attribute","value":"custom_headers"},{"type":"map_key","value":"x-client-secret"},{"type":"attribute","value":"value_wo"}]`, string(key))
+}
+
+func TestWriteOnlyCredentialPathMapKeysDoNotCollideWithDisplayPathSyntax(t *testing.T) {
+	t.Parallel()
+
+	key := `x-"secret"\key`
+	expectedPath := path.Root("credentials").AtName("custom_headers").AtMapKey(key).AtName("value_wo")
+	keyWithSpecialCharacters := mustWriteOnlyCredentialPath(t, expectedPath)
+	displayLikeKey := mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("custom_headers").AtMapKey(`x-\"secret\"\\key`).AtName("value_wo"))
+
+	plan := CustomAPIDestinationModel{
+		Credentials: NewTypedObject(CustomAPIDestinationCredentials{
+			CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationCustomHeader]{
+				key: NewTypedObject(CustomAPIDestinationCustomHeader{
+					Value:    types.StringNull(),
+					IsSecret: types.BoolValue(true),
+				}),
+			}),
+		}),
+	}
+	config := CustomAPIDestinationModel{
+		Credentials: NewTypedObject(CustomAPIDestinationCredentials{
+			CustomHeaders: NewTypedMap(map[string]TypedObject[CustomAPIDestinationCustomHeader]{
+				key: NewTypedObject(CustomAPIDestinationCustomHeader{
+					ValueWO:  types.StringValue("secret"),
+					IsSecret: types.BoolValue(true),
+				}),
+			}),
+		}),
+	}
+
+	_, values, diags := customAPIDestinationModelWithWriteOnlyCredentials(plan, config)
+	require.False(t, diags.HasError(), diags)
+	assert.Contains(t, values, keyWithSpecialCharacters)
+	assert.NotContains(t, values, `credentials.custom_headers["x-"secret"\key"].value_wo`)
+	assert.NotEqual(t, keyWithSpecialCharacters, displayLikeKey)
+}
+
+func TestWriteOnlyCredentialPathRejectsUnsupportedPathSteps(t *testing.T) {
+	t.Parallel()
+
+	_, diags := writeOnlyCredentialPathFromPath(path.Root("credentials").AtListIndex(0))
+
+	assert.True(t, diags.HasError())
+}
+
+func TestWriteOnlyCredentialValuesTracksOnlyConfiguredValues(t *testing.T) {
+	t.Parallel()
+
+	nullPath := path.Root("credentials").AtName("null_wo")
+	unknownPath := path.Root("credentials").AtName("unknown_wo")
+	knownPath := path.Root("credentials").AtName("known_wo")
+	values := writeOnlyCredentialValues{}
+
+	require.False(t, values.Add(nullPath, types.StringNull()).HasError())
+	require.False(t, values.Add(unknownPath, types.StringUnknown()).HasError())
+	require.False(t, values.Add(knownPath, types.StringValue("secret")).HasError())
+
+	assert.NotContains(t, values, mustWriteOnlyCredentialPath(t, nullPath))
+	assert.True(t, values[mustWriteOnlyCredentialPath(t, unknownPath)].IsUnknown())
+	assert.Equal(t, "secret", values[mustWriteOnlyCredentialPath(t, knownPath)].ValueString())
+}
+
+func TestWriteOnlyCredentialVerifiersChangedDetectsRemovedWriteOnlyCredential(t *testing.T) {
+	t.Parallel()
+
+	private := fakePrivateStateReader{
+		values: map[string][]byte{
+			writeOnlyCredentialVerifiersPrivateKey: mustJSONMarshal(t, map[string]string{
+				string(mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("client_key_wo"))): mustWriteOnlyCredentialVerifier(t, path.Root("credentials").AtName("client_key_wo"), types.StringValue("previous-secret")),
+			}),
+		},
+	}
+
+	changed, diags := writeOnlyCredentialVerifiersChanged(context.Background(), private, writeOnlyCredentialValues{})
+
+	require.False(t, diags.HasError(), diags)
+	assert.True(t, changed)
+}
+
+func TestWriteOnlyCredentialVerifiersChangedDetectsAddedOrChangedWriteOnlyCredential(t *testing.T) {
+	t.Parallel()
+
+	apiKeyPath := path.Root("credentials").AtName("api_key_wo")
+	clientKeyPath := path.Root("credentials").AtName("client_key_wo")
+
+	private := fakePrivateStateReader{
+		values: map[string][]byte{
+			writeOnlyCredentialVerifiersPrivateKey: mustJSONMarshal(t, map[string]string{
+				string(mustWriteOnlyCredentialPath(t, apiKeyPath)): mustWriteOnlyCredentialVerifier(t, apiKeyPath, types.StringValue("api-key")),
+			}),
+		},
+	}
+
+	changed, diags := writeOnlyCredentialVerifiersChanged(context.Background(), private, writeOnlyCredentialValues{
+		mustWriteOnlyCredentialPath(t, apiKeyPath):    types.StringValue("api-key"),
+		mustWriteOnlyCredentialPath(t, clientKeyPath): types.StringValue("client-key"),
+	})
+
+	require.False(t, diags.HasError(), diags)
+	assert.True(t, changed)
+}
+
+func TestWriteOnlyCredentialVerifiersChangedDetectsChangedWriteOnlyCredential(t *testing.T) {
+	t.Parallel()
+
+	apiKeyPath := path.Root("credentials").AtName("api_key_wo")
+
+	private := fakePrivateStateReader{
+		values: map[string][]byte{
+			writeOnlyCredentialVerifiersPrivateKey: mustJSONMarshal(t, map[string]string{
+				string(mustWriteOnlyCredentialPath(t, apiKeyPath)): mustWriteOnlyCredentialVerifier(t, apiKeyPath, types.StringValue("api-key")),
+			}),
+		},
+	}
+
+	changed, diags := writeOnlyCredentialVerifiersChanged(context.Background(), private, writeOnlyCredentialValues{
+		mustWriteOnlyCredentialPath(t, apiKeyPath): types.StringValue("rotated-api-key"),
+	})
+
+	require.False(t, diags.HasError(), diags)
+	assert.True(t, changed)
+}
+
+func TestWriteOnlyCredentialVerifiersChangedIgnoresUnchangedValues(t *testing.T) {
+	t.Parallel()
+
+	apiKeyPath := path.Root("credentials").AtName("api_key_wo")
+	apiKeyKey := mustWriteOnlyCredentialPath(t, apiKeyPath)
+	values := writeOnlyCredentialValues{
+		apiKeyKey: types.StringValue("current-secret"),
+	}
+
+	private := fakePrivateStateReader{
+		values: map[string][]byte{
+			writeOnlyCredentialVerifiersPrivateKey: mustJSONMarshal(t, map[string]string{
+				string(apiKeyKey): mustWriteOnlyCredentialVerifier(t, apiKeyPath, values[apiKeyKey]),
+			}),
+		},
+	}
+
+	changed, diags := writeOnlyCredentialVerifiersChanged(context.Background(), private, values)
+
+	require.False(t, diags.HasError(), diags)
+	assert.False(t, changed)
+}
+
+func TestWriteOnlyCredentialVerifiersChangedDetectsUnknownConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	apiKeyPath := path.Root("credentials").AtName("api_key_wo")
+	apiKeyKey := mustWriteOnlyCredentialPath(t, apiKeyPath)
+
+	private := fakePrivateStateReader{
+		values: map[string][]byte{
+			writeOnlyCredentialVerifiersPrivateKey: mustJSONMarshal(t, map[string]string{
+				string(apiKeyKey): mustWriteOnlyCredentialVerifier(t, apiKeyPath, types.StringValue("")),
+			}),
+		},
+	}
+
+	changed, diags := writeOnlyCredentialVerifiersChanged(context.Background(), private, writeOnlyCredentialValues{
+		apiKeyKey: types.StringUnknown(),
+	})
+
+	require.False(t, diags.HasError(), diags)
+	assert.True(t, changed)
+}
+
+func TestWriteOnlyCredentialVerifiersRejectUnknownConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	writer := fakePrivateStateWriter{}
+
+	diags := writeWriteOnlyCredentialVerifiers(context.Background(), &writer, writeOnlyCredentialValues{
+		mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("api_key_wo")): types.StringUnknown(),
+	})
+
+	assert.True(t, diags.HasError())
+	assert.Empty(t, writer.values)
+}
+
+func TestWriteOnlyCredentialVerifiersWriteKnownConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	writer := fakePrivateStateWriter{}
+
+	diags := writeWriteOnlyCredentialVerifiers(context.Background(), &writer, writeOnlyCredentialValues{
+		mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("api_key_wo")): types.StringValue("secret"),
+	})
+
+	require.False(t, diags.HasError(), diags)
+	assert.NotEmpty(t, writer.values[writeOnlyCredentialVerifiersPrivateKey])
+}
+
+func TestValidateWriteOnlyCredentialValuesKnownRejectsUnknownValue(t *testing.T) {
+	t.Parallel()
+
+	diags := validateWriteOnlyCredentialValuesKnown(writeOnlyCredentialValues{
+		mustWriteOnlyCredentialPath(t, path.Root("credentials").AtName("api_key_wo")): types.StringUnknown(),
+	})
+
+	assert.True(t, diags.HasError())
+}
+
+type fakePrivateStateReader struct {
+	values map[string][]byte
+}
+
+func (r fakePrivateStateReader) GetKey(_ context.Context, key string) ([]byte, diag.Diagnostics) {
+	return r.values[key], nil
+}
+
+type fakePrivateStateWriter struct {
+	values map[string][]byte
+}
+
+func (w *fakePrivateStateWriter) SetKey(_ context.Context, key string, value []byte) diag.Diagnostics {
+	if w.values == nil {
+		w.values = map[string][]byte{}
+	}
+
+	w.values[key] = value
+
+	return nil
+}
+
+func mustJSONMarshal(t *testing.T, value any) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	return data
+}
+
+func mustWriteOnlyCredentialVerifier(t *testing.T, argumentPath path.Path, value types.String) string {
+	t.Helper()
+
+	key := mustWriteOnlyCredentialPath(t, argumentPath)
+	verifier, err := writeOnlyCredentialVerifier(key, value)
+	require.NoError(t, err)
+
+	return verifier
+}
+
+func mustWriteOnlyCredentialPath(t *testing.T, argumentPath path.Path) writeOnlyCredentialPath {
+	t.Helper()
+
+	key, diags := writeOnlyCredentialPathFromPath(argumentPath)
+	require.False(t, diags.HasError(), diags)
+
+	return key
+}


### PR DESCRIPTION
## Summary
- support write-only credential alternatives for typed Braze, BigQuery, and Custom API resources
- keep existing sensitive fields supported without deprecation
- resolve write-only values from config, sanitize state, and store path-scoped private Argon2id verifiers for change detection
- preserve partial state IDs after successful creates before post-create read-back
- regenerate provider docs

## Verification
- go generate ./...
- go test ./...
- golangci-lint run
- TF_ACC=1 TF_ACC_MOCKED=1 go test ./internal/provider -run 'TestAccBrazeDestinationResourceWriteOnlyCredentials|TestAccCustomAPIDestinationResourceWriteOnlyHeaders|TestAccBigQuerySourceResourceWriteOnlyCredentials' -count=1
- real dev read-only terraform plan with local provider override: no changes
