### PR TITLE
document(provider): describe schema fields

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,12 @@
 page_title: "censusworkspace Provider"
 subcategory: ""
 description: |-
-  Manage a Census workspace.
+  Manage resources in a Census workspace.
 ---
 
 # censusworkspace Provider
 
-Manage a Census workspace.
+Manage resources in a Census workspace.
 
 ## Example Usage
 
@@ -24,5 +24,5 @@ provider "censusworkspace" {
 
 ### Optional
 
-- `base_url` (String) The base URL associated with your Census organization's region. If not provided, it will default to the value of the CENSUS_BASE_URL environment variable or the provider's default base URL.
-- `workspace_api_key` (String, Sensitive) The API key for your Census workspace. If not provided, it will default to the value of the CENSUS_WORKSPACE_API_KEY environment variable.
+- `base_url` (String) Census API base URL for your organization's region. May also be set with CENSUS_BASE_URL. Defaults to the provider's default base URL.
+- `workspace_api_key` (String, Sensitive) Census workspace API key used to authenticate provider requests. May also be set with CENSUS_WORKSPACE_API_KEY.

--- a/docs/resources/big_query_destination.md
+++ b/docs/resources/big_query_destination.md
@@ -28,25 +28,25 @@ resource "censusworkspace_big_query_destination" "test" {
 
 ### Required
 
-- `credentials` (Attributes) (see [below for nested schema](#nestedatt--credentials))
+- `credentials` (Attributes) BigQuery destination connection values to send to Census. (see [below for nested schema](#nestedatt--credentials))
 - `name` (String) The name of this destination.
 
 ### Read-Only
 
-- `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `id` (String) The ID of this resource.
+- `connection_details` (Attributes) BigQuery destination connection details returned by Census. (see [below for nested schema](#nestedatt--connection_details))
+- `id` (String) Census identifier for this destination.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`
 
 Required:
 
-- `location` (String)
-- `project_id` (String)
+- `location` (String) BigQuery location of the destination dataset.
+- `project_id` (String) Google Cloud project ID containing the BigQuery destination dataset.
 
 Optional:
 
-- `service_account_key` (String, Sensitive)
+- `service_account_key` (String, Sensitive) Service account key JSON used by Census to write to BigQuery.
 
 
 <a id="nestedatt--connection_details"></a>
@@ -54,10 +54,10 @@ Optional:
 
 Read-Only:
 
-- `location` (String)
-- `project_id` (String)
-- `service_account_email` (String)
-- `service_account_key` (String, Sensitive)
+- `location` (String) BigQuery location Census has stored for this BigQuery destination.
+- `project_id` (String) Google Cloud project ID Census has stored for this BigQuery destination.
+- `service_account_email` (String) Service account email Census uses for this BigQuery destination.
+- `service_account_key` (String, Sensitive) Service account key value returned by Census for this BigQuery destination, when available.
 
 ## Import
 

--- a/docs/resources/big_query_source.md
+++ b/docs/resources/big_query_source.md
@@ -30,7 +30,7 @@ resource "censusworkspace_big_query_source" "test" {
 
 ### Required
 
-- `credentials` (Attributes) (see [below for nested schema](#nestedatt--credentials))
+- `credentials` (Attributes) BigQuery source connection values to send to Census. (see [below for nested schema](#nestedatt--credentials))
 - `name` (String) The name assigned to this source.
 
 ### Optional
@@ -40,33 +40,33 @@ resource "censusworkspace_big_query_source" "test" {
 
 ### Read-Only
 
-- `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `id` (String) The ID of this resource.
-- `label` (String, Deprecated) Deprecated. Use `name` for configuration. This read-only field reflects the API label when returned.
+- `connection_details` (Attributes) BigQuery source connection details returned by Census. (see [below for nested schema](#nestedatt--connection_details))
+- `id` (String) Census identifier for this source.
+- `label` (String, Deprecated) Deprecated. Use `name` instead. This read-only field reflects the source label returned by the Census API.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`
 
 Required:
 
-- `location` (String)
-- `project_id` (String)
+- `location` (String) BigQuery location of the source data.
+- `project_id` (String) Google Cloud project ID containing the BigQuery source data.
 
 Optional:
 
-- `service_account_key` (Attributes) (see [below for nested schema](#nestedatt--credentials--service_account_key))
+- `service_account_key` (Attributes) Service account key JSON fields used by Census to read from BigQuery. (see [below for nested schema](#nestedatt--credentials--service_account_key))
 
 <a id="nestedatt--credentials--service_account_key"></a>
 ### Nested Schema for `credentials.service_account_key`
 
 Required:
 
-- `client_email` (String)
-- `client_id` (String)
-- `private_key` (String, Sensitive)
-- `private_key_id` (String)
-- `project_id` (String)
-- `type` (String)
+- `client_email` (String) Client email from the service account key JSON.
+- `client_id` (String) Client ID from the service account key JSON.
+- `private_key` (String, Sensitive) Private key from the service account key JSON.
+- `private_key_id` (String) Private key ID from the service account key JSON.
+- `project_id` (String) Google Cloud project ID from the service account key JSON.
+- `type` (String) Service account key type. Must be `service_account`.
 
 
 
@@ -75,9 +75,9 @@ Required:
 
 Read-Only:
 
-- `location` (String)
-- `project_id` (String)
-- `service_account` (String)
+- `location` (String) BigQuery location Census has stored for this BigQuery source.
+- `project_id` (String) Google Cloud project ID Census has stored for this BigQuery source.
+- `service_account` (String) Census-managed service account email address for this BigQuery source.
 
 ## Import
 

--- a/docs/resources/braze_destination.md
+++ b/docs/resources/braze_destination.md
@@ -17,25 +17,25 @@ description: |-
 
 ### Required
 
-- `credentials` (Attributes) (see [below for nested schema](#nestedatt--credentials))
+- `credentials` (Attributes) Braze destination connection values to send to Census. (see [below for nested schema](#nestedatt--credentials))
 - `name` (String) The name of this destination.
 
 ### Read-Only
 
-- `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `id` (String) The ID of this resource.
+- `connection_details` (Attributes) Braze destination connection details returned by Census. (see [below for nested schema](#nestedatt--connection_details))
+- `id` (String) Census identifier for this destination.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`
 
 Required:
 
-- `api_key` (String, Sensitive) API Key
-- `instance_url` (String) Endpoint URL
+- `api_key` (String, Sensitive) Braze REST API key Census uses to update users.
+- `instance_url` (String) Braze REST API endpoint URL for the destination instance.
 
 Optional:
 
-- `client_key` (String, Sensitive) Data Import Key (for Cohorts only)
+- `client_key` (String, Sensitive) Braze Data Import Key used when syncing Cohorts.
 
 
 <a id="nestedatt--connection_details"></a>
@@ -43,6 +43,6 @@ Optional:
 
 Read-Only:
 
-- `instance_url` (String) Endpoint URL
+- `instance_url` (String) Braze REST API endpoint URL Census has stored for this destination.
 
 

--- a/docs/resources/custom_api_destination.md
+++ b/docs/resources/custom_api_destination.md
@@ -37,36 +37,36 @@ resource "censusworkspace_custom_api_destination" "this" {
 
 ### Required
 
-- `credentials` (Attributes) (see [below for nested schema](#nestedatt--credentials))
+- `credentials` (Attributes) Custom API destination connection values to send to Census. (see [below for nested schema](#nestedatt--credentials))
 - `name` (String) The name of this destination.
 
 ### Read-Only
 
-- `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `id` (String) The ID of this resource.
+- `connection_details` (Attributes) Custom API destination connection details returned by Census. (see [below for nested schema](#nestedatt--connection_details))
+- `id` (String) Census identifier for this destination.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`
 
 Required:
 
-- `api_version` (Number)
-- `webhook_url` (String)
+- `api_version` (Number) Custom Destination API version implemented by your endpoint.
+- `webhook_url` (String) Public webhook URL Census calls for Custom API destination syncs.
 
 Optional:
 
-- `custom_headers` (Attributes Map) (see [below for nested schema](#nestedatt--credentials--custom_headers))
+- `custom_headers` (Attributes Map) Additional HTTP headers Census sends to the Custom API webhook. (see [below for nested schema](#nestedatt--credentials--custom_headers))
 
 <a id="nestedatt--credentials--custom_headers"></a>
 ### Nested Schema for `credentials.custom_headers`
 
 Required:
 
-- `value` (String)
+- `value` (String) HTTP header value sent to the Custom API webhook.
 
 Optional:
 
-- `is_secret` (Boolean)
+- `is_secret` (Boolean) Whether Census should store this header value as a secret.
 
 
 
@@ -75,17 +75,17 @@ Optional:
 
 Read-Only:
 
-- `api_version` (Number)
-- `custom_headers` (Attributes Map) (see [below for nested schema](#nestedatt--connection_details--custom_headers))
-- `webhook_url` (String)
+- `api_version` (Number) Custom Destination API version Census has stored for this destination.
+- `custom_headers` (Attributes Map) Additional HTTP headers Census has stored for this Custom API webhook. (see [below for nested schema](#nestedatt--connection_details--custom_headers))
+- `webhook_url` (String) Public webhook URL Census has stored for this Custom API destination.
 
 <a id="nestedatt--connection_details--custom_headers"></a>
 ### Nested Schema for `connection_details.custom_headers`
 
 Read-Only:
 
-- `is_secret` (Boolean)
-- `value` (String)
+- `is_secret` (Boolean) Whether Census stores this header value as a secret.
+- `value` (String) HTTP header value returned by Census, or null when the header is secret.
 
 ## Import
 

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -39,7 +39,7 @@ resource "censusworkspace_destination" "test" {
 ### Read-Only
 
 - `connection_details` (String) Connection details associated with this destination.
-- `id` (String) The ID of this resource.
+- `id` (String) Census identifier for this destination.
 
 ## Import
 

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -43,8 +43,8 @@ resource "censusworkspace_source" "test" {
 ### Read-Only
 
 - `connection_details` (String) Detailed configuration and information for connecting to this source.
-- `id` (String) The ID of this resource.
-- `label` (String, Deprecated) Deprecated. Use `name` for configuration. This read-only field reflects the API label when returned.
+- `id` (String) Census identifier for this source.
+- `label` (String, Deprecated) Deprecated. Use `name` instead. This read-only field reflects the source label returned by the Census API.
 
 ## Import
 

--- a/docs/resources/sql_dataset.md
+++ b/docs/resources/sql_dataset.md
@@ -23,10 +23,10 @@ description: |-
 
 ### Optional
 
-- `description` (String) Description of the dataset.
+- `description` (String) Human-readable description shown for this SQL dataset in Census.
 
 ### Read-Only
 
-- `id` (String) The ID of this resource.
+- `id` (String) Census identifier for this SQL dataset.
 
 

--- a/internal/provider/big_query_destination_resource_schema.go
+++ b/internal/provider/big_query_destination_resource_schema.go
@@ -34,23 +34,27 @@ func BigQueryDestinationResourceSchema(ctx context.Context) schema.Schema {
 //nolint:ireturn
 func BigQueryDestinationCredentialsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: BigQueryDestinationCredentialsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[BigQueryDestinationCredentials]().CustomType(ctx),
-		Required:   true,
+		Attributes:          BigQueryDestinationCredentialsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[BigQueryDestinationCredentials]().CustomType(ctx),
+		Required:            true,
+		MarkdownDescription: "BigQuery destination connection values to send to Census.",
 	}
 }
 
 func BigQueryDestinationCredentialsResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"project_id": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Google Cloud project ID containing the BigQuery destination dataset.",
 		},
 		"location": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "BigQuery location of the destination dataset.",
 		},
 		"service_account_key": schema.StringAttribute{
-			Optional:  true,
-			Sensitive: true,
+			Optional:            true,
+			Sensitive:           true,
+			MarkdownDescription: "Service account key JSON used by Census to write to BigQuery.",
 		},
 	}
 }
@@ -58,26 +62,31 @@ func BigQueryDestinationCredentialsResourceSchemaAttributes(_ context.Context) m
 //nolint:ireturn
 func BigQueryDestinationConnectionDetailsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: BigQueryDestinationConnectionDetailsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[BigQueryDestinationConnectionDetails]().CustomType(ctx),
-		Computed:   true,
+		Attributes:          BigQueryDestinationConnectionDetailsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[BigQueryDestinationConnectionDetails]().CustomType(ctx),
+		Computed:            true,
+		MarkdownDescription: "BigQuery destination connection details returned by Census.",
 	}
 }
 
 func BigQueryDestinationConnectionDetailsResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"project_id": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Google Cloud project ID Census has stored for this BigQuery destination.",
 		},
 		"location": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "BigQuery location Census has stored for this BigQuery destination.",
 		},
 		"service_account_email": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Service account email Census uses for this BigQuery destination.",
 		},
 		"service_account_key": schema.StringAttribute{
-			Computed:  true,
-			Sensitive: true,
+			Computed:            true,
+			Sensitive:           true,
+			MarkdownDescription: "Service account key value returned by Census for this BigQuery destination, when available.",
 		},
 	}
 }

--- a/internal/provider/big_query_source_resource_schema.go
+++ b/internal/provider/big_query_source_resource_schema.go
@@ -36,24 +36,28 @@ func BigQuerySourceResourceSchema(ctx context.Context) schema.Schema {
 //nolint:ireturn
 func BigQuerySourceCredentialsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: BigQuerySourceCredentialsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[BigQuerySourceCredentials]().CustomType(ctx),
-		Required:   true,
+		Attributes:          BigQuerySourceCredentialsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[BigQuerySourceCredentials]().CustomType(ctx),
+		Required:            true,
+		MarkdownDescription: "BigQuery source connection values to send to Census.",
 	}
 }
 
 func BigQuerySourceCredentialsResourceSchemaAttributes(ctx context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"project_id": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Google Cloud project ID containing the BigQuery source data.",
 		},
 		"location": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "BigQuery location of the source data.",
 		},
 		"service_account_key": schema.SingleNestedAttribute{
-			Optional:   true,
-			Attributes: BigQuerySourceCredentialsServiceAccountKeyResourceSchemaAttributes(ctx),
-			CustomType: NewTypedObjectNull[BigQuerySourceCredentialsServiceAccountKey]().CustomType(ctx),
+			Optional:            true,
+			Attributes:          BigQuerySourceCredentialsServiceAccountKeyResourceSchemaAttributes(ctx),
+			CustomType:          NewTypedObjectNull[BigQuerySourceCredentialsServiceAccountKey]().CustomType(ctx),
+			MarkdownDescription: "Service account key JSON fields used by Census to read from BigQuery.",
 		},
 	}
 }
@@ -65,22 +69,28 @@ func BigQuerySourceCredentialsServiceAccountKeyResourceSchemaAttributes(_ contex
 			Validators: []validator.String{
 				stringvalidator.OneOf("service_account"),
 			},
+			MarkdownDescription: "Service account key type. Must be `service_account`.",
 		},
 		"project_id": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Google Cloud project ID from the service account key JSON.",
 		},
 		"private_key_id": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Private key ID from the service account key JSON.",
 		},
 		"private_key": schema.StringAttribute{
-			Sensitive: true,
-			Required:  true,
+			Sensitive:           true,
+			Required:            true,
+			MarkdownDescription: "Private key from the service account key JSON.",
 		},
 		"client_email": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Client email from the service account key JSON.",
 		},
 		"client_id": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Client ID from the service account key JSON.",
 		},
 	}
 }
@@ -88,22 +98,26 @@ func BigQuerySourceCredentialsServiceAccountKeyResourceSchemaAttributes(_ contex
 //nolint:ireturn
 func BigQuerySourceConnectionDetailsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: BigQuerySourceConnectionDetailsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[BigQuerySourceConnectionDetails]().CustomType(ctx),
-		Computed:   true,
+		Attributes:          BigQuerySourceConnectionDetailsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[BigQuerySourceConnectionDetails]().CustomType(ctx),
+		Computed:            true,
+		MarkdownDescription: "BigQuery source connection details returned by Census.",
 	}
 }
 
 func BigQuerySourceConnectionDetailsResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"project_id": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Google Cloud project ID Census has stored for this BigQuery source.",
 		},
 		"location": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "BigQuery location Census has stored for this BigQuery source.",
 		},
 		"service_account": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Census-managed service account email address for this BigQuery source.",
 		},
 	}
 }

--- a/internal/provider/braze_destination_resource_schema.go
+++ b/internal/provider/braze_destination_resource_schema.go
@@ -34,27 +34,28 @@ func BrazeDestinationResourceSchema(ctx context.Context) schema.Schema {
 //nolint:ireturn
 func BrazeDestinationCredentialsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: BrazeDestinationCredentialsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[BrazeDestinationCredentials]().CustomType(ctx),
-		Required:   true,
+		Attributes:          BrazeDestinationCredentialsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[BrazeDestinationCredentials]().CustomType(ctx),
+		Required:            true,
+		MarkdownDescription: "Braze destination connection values to send to Census.",
 	}
 }
 
 func BrazeDestinationCredentialsResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"instance_url": schema.StringAttribute{
-			Required:    true,
-			Description: "Endpoint URL",
+			Required:            true,
+			MarkdownDescription: "Braze REST API endpoint URL for the destination instance.",
 		},
 		"api_key": schema.StringAttribute{
-			Required:    true,
-			Sensitive:   true,
-			Description: "API Key",
+			Required:            true,
+			Sensitive:           true,
+			MarkdownDescription: "Braze REST API key Census uses to update users.",
 		},
 		"client_key": schema.StringAttribute{
-			Optional:    true,
-			Sensitive:   true,
-			Description: "Data Import Key (for Cohorts only)",
+			Optional:            true,
+			Sensitive:           true,
+			MarkdownDescription: "Braze Data Import Key used when syncing Cohorts.",
 		},
 	}
 }
@@ -62,17 +63,18 @@ func BrazeDestinationCredentialsResourceSchemaAttributes(_ context.Context) map[
 //nolint:ireturn
 func BrazeDestinationConnectionDetailsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: BrazeDestinationConnectionDetailsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[BrazeDestinationConnectionDetails]().CustomType(ctx),
-		Computed:   true,
+		Attributes:          BrazeDestinationConnectionDetailsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[BrazeDestinationConnectionDetails]().CustomType(ctx),
+		Computed:            true,
+		MarkdownDescription: "Braze destination connection details returned by Census.",
 	}
 }
 
 func BrazeDestinationConnectionDetailsResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"instance_url": schema.StringAttribute{
-			Computed:    true,
-			Description: "Endpoint URL",
+			Computed:            true,
+			MarkdownDescription: "Braze REST API endpoint URL Census has stored for this destination.",
 		},
 	}
 }

--- a/internal/provider/custom_api_destination_resource_schema.go
+++ b/internal/provider/custom_api_destination_resource_schema.go
@@ -35,22 +35,26 @@ func CustomAPIDestinationResourceSchema(ctx context.Context) schema.Schema {
 //nolint:ireturn
 func CustomAPIDestinationCredentialsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: CustomAPIDestinationCredentialsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[CustomAPIDestinationCredentials]().CustomType(ctx),
-		Required:   true,
+		Attributes:          CustomAPIDestinationCredentialsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[CustomAPIDestinationCredentials]().CustomType(ctx),
+		Required:            true,
+		MarkdownDescription: "Custom API destination connection values to send to Census.",
 	}
 }
 
 func CustomAPIDestinationCredentialsResourceSchemaAttributes(ctx context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"api_version": schema.Int64Attribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Custom Destination API version implemented by your endpoint.",
 		},
 		"webhook_url": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "Public webhook URL Census calls for Custom API destination syncs.",
 		},
 		"custom_headers": schema.MapNestedAttribute{
-			Optional: true,
+			Optional:            true,
+			MarkdownDescription: "Additional HTTP headers Census sends to the Custom API webhook.",
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: CustomAPIDestinationCredentialsCustomHeaderResourceSchemaAttributes(ctx),
 				CustomType: NewTypedObjectNull[CustomAPIDestinationCustomHeader]().CustomType(ctx),
@@ -63,12 +67,14 @@ func CustomAPIDestinationCredentialsResourceSchemaAttributes(ctx context.Context
 func CustomAPIDestinationCredentialsCustomHeaderResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"value": schema.StringAttribute{
-			Required: true,
+			Required:            true,
+			MarkdownDescription: "HTTP header value sent to the Custom API webhook.",
 		},
 		"is_secret": schema.BoolAttribute{
-			Optional: true,
-			Computed: true,
-			Default:  booldefault.StaticBool(false),
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "Whether Census should store this header value as a secret.",
 		},
 	}
 }
@@ -76,22 +82,26 @@ func CustomAPIDestinationCredentialsCustomHeaderResourceSchemaAttributes(_ conte
 //nolint:ireturn
 func CustomAPIDestinationConnectionDetailsResourceSchema(ctx context.Context) schema.Attribute {
 	return schema.SingleNestedAttribute{
-		Attributes: CustomAPIDestinationConnectionDetailsResourceSchemaAttributes(ctx),
-		CustomType: NewTypedObjectNull[CustomAPIDestinationConnectionDetails]().CustomType(ctx),
-		Computed:   true,
+		Attributes:          CustomAPIDestinationConnectionDetailsResourceSchemaAttributes(ctx),
+		CustomType:          NewTypedObjectNull[CustomAPIDestinationConnectionDetails]().CustomType(ctx),
+		Computed:            true,
+		MarkdownDescription: "Custom API destination connection details returned by Census.",
 	}
 }
 
 func CustomAPIDestinationConnectionDetailsResourceSchemaAttributes(ctx context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"api_version": schema.Int64Attribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Custom Destination API version Census has stored for this destination.",
 		},
 		"webhook_url": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Public webhook URL Census has stored for this Custom API destination.",
 		},
 		"custom_headers": schema.MapNestedAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Additional HTTP headers Census has stored for this Custom API webhook.",
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: CustomAPIDestinationConnectionDetailsCustomHeaderResourceSchemaAttributes(ctx),
 				CustomType: NewTypedObjectNull[CustomAPIDestinationCustomHeader]().CustomType(ctx),
@@ -104,10 +114,12 @@ func CustomAPIDestinationConnectionDetailsResourceSchemaAttributes(ctx context.C
 func CustomAPIDestinationConnectionDetailsCustomHeaderResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"value": schema.StringAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "HTTP header value returned by Census, or null when the header is secret.",
 		},
 		"is_secret": schema.BoolAttribute{
-			Computed: true,
+			Computed:            true,
+			MarkdownDescription: "Whether Census stores this header value as a secret.",
 		},
 	}
 }

--- a/internal/provider/destination_base.go
+++ b/internal/provider/destination_base.go
@@ -21,6 +21,7 @@ func destinationBaseResourceSchemaAttributes(_ context.Context) map[string]schem
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},
+			MarkdownDescription: "Census identifier for this destination.",
 		},
 		"name": schema.StringAttribute{
 			Required:            true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -75,14 +75,14 @@ func WithWorkspaceAPIKey(apiKey string) Option {
 
 func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Manage a Census workspace.",
+		Description: "Manage resources in a Census workspace.",
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
-				Description: "The base URL associated with your Census organization's region. If not provided, it will default to the value of the CENSUS_BASE_URL environment variable or the provider's default base URL.",
+				Description: "Census API base URL for your organization's region. May also be set with CENSUS_BASE_URL. Defaults to the provider's default base URL.",
 				Optional:    true,
 			},
 			"workspace_api_key": schema.StringAttribute{
-				Description: "The API key for your Census workspace. If not provided, it will default to the value of the CENSUS_WORKSPACE_API_KEY environment variable.",
+				Description: "Census workspace API key used to authenticate provider requests. May also be set with CENSUS_WORKSPACE_API_KEY.",
 				Optional:    true,
 				Sensitive:   true,
 			},

--- a/internal/provider/source_base.go
+++ b/internal/provider/source_base.go
@@ -27,6 +27,7 @@ func sourceBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Att
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},
+			MarkdownDescription: "Census identifier for this source.",
 		},
 		"name": schema.StringAttribute{
 			Required:            true,
@@ -35,7 +36,7 @@ func sourceBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Att
 		"label": schema.StringAttribute{
 			Computed:            true,
 			DeprecationMessage:  "Use name instead.",
-			MarkdownDescription: "Deprecated. Use `name` for configuration. This read-only field reflects the API label when returned.",
+			MarkdownDescription: "Deprecated. Use `name` instead. This read-only field reflects the source label returned by the Census API.",
 		},
 		"sync_engine": schema.StringAttribute{
 			Optional: true,

--- a/internal/provider/sql_dataset_resource_schema.go
+++ b/internal/provider/sql_dataset_resource_schema.go
@@ -28,6 +28,7 @@ func SQLDatasetResourceSchema(_ context.Context) schema.Schema {
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+				MarkdownDescription: "Census identifier for this SQL dataset.",
 			},
 			"name": schema.StringAttribute{
 				Required:            true,
@@ -47,7 +48,7 @@ func SQLDatasetResourceSchema(_ context.Context) schema.Schema {
 			},
 			"description": schema.StringAttribute{
 				Optional:            true,
-				MarkdownDescription: "Description of the dataset.",
+				MarkdownDescription: "Human-readable description shown for this SQL dataset in Census.",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- add concise descriptions for provider schema arguments and attributes
- use Census API and developer documentation wording where available
- regenerate Terraform provider docs from the updated schema

## Validation

- `go generate ./...`
- `go test ./...`
