### PR TITLE
feat(provider): remove resource metadata fields

### DIFF
--- a/docs/resources/big_query_destination.md
+++ b/docs/resources/big_query_destination.md
@@ -34,7 +34,6 @@ resource "censusworkspace_big_query_destination" "test" {
 ### Read-Only
 
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `created_at` (String) When the connection was created
 - `id` (String) The ID of this resource.
 - `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
 - `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.

--- a/docs/resources/big_query_destination.md
+++ b/docs/resources/big_query_destination.md
@@ -35,8 +35,6 @@ resource "censusworkspace_big_query_destination" "test" {
 
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
 - `id` (String) The ID of this resource.
-- `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
-- `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/docs/resources/big_query_source.md
+++ b/docs/resources/big_query_source.md
@@ -41,7 +41,6 @@ resource "censusworkspace_big_query_source" "test" {
 ### Read-Only
 
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `created_at` (String) When the connection was created
 - `id` (String) The ID of this resource.
 - `label` (String, Deprecated) Deprecated. Use `name` for configuration. This read-only field reflects the API label when returned.
 - `last_test_succeeded` (Boolean) Indicates if the last connection test to this source was successful.

--- a/docs/resources/big_query_source.md
+++ b/docs/resources/big_query_source.md
@@ -43,8 +43,6 @@ resource "censusworkspace_big_query_source" "test" {
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
 - `id` (String) The ID of this resource.
 - `label` (String, Deprecated) Deprecated. Use `name` for configuration. This read-only field reflects the API label when returned.
-- `last_test_succeeded` (Boolean) Indicates if the last connection test to this source was successful.
-- `last_tested_at` (String) Timestamp of when the last connection test was conducted on this source.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/docs/resources/braze_destination.md
+++ b/docs/resources/braze_destination.md
@@ -24,8 +24,6 @@ description: |-
 
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
 - `id` (String) The ID of this resource.
-- `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
-- `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`
@@ -46,4 +44,5 @@ Optional:
 Read-Only:
 
 - `instance_url` (String) Endpoint URL
+
 

--- a/docs/resources/braze_destination.md
+++ b/docs/resources/braze_destination.md
@@ -23,7 +23,6 @@ description: |-
 ### Read-Only
 
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `created_at` (String) When the connection was created
 - `id` (String) The ID of this resource.
 - `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
 - `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.
@@ -47,5 +46,4 @@ Optional:
 Read-Only:
 
 - `instance_url` (String) Endpoint URL
-
 

--- a/docs/resources/custom_api_destination.md
+++ b/docs/resources/custom_api_destination.md
@@ -43,7 +43,6 @@ resource "censusworkspace_custom_api_destination" "this" {
 ### Read-Only
 
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
-- `created_at` (String) When the connection was created
 - `id` (String) The ID of this resource.
 - `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
 - `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.

--- a/docs/resources/custom_api_destination.md
+++ b/docs/resources/custom_api_destination.md
@@ -44,8 +44,6 @@ resource "censusworkspace_custom_api_destination" "this" {
 
 - `connection_details` (Attributes) (see [below for nested schema](#nestedatt--connection_details))
 - `id` (String) The ID of this resource.
-- `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
-- `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -39,7 +39,6 @@ resource "censusworkspace_destination" "test" {
 ### Read-Only
 
 - `connection_details` (String) Connection details associated with this destination.
-- `created_at` (String) When the connection was created
 - `id` (String) The ID of this resource.
 - `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
 - `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -40,8 +40,6 @@ resource "censusworkspace_destination" "test" {
 
 - `connection_details` (String) Connection details associated with this destination.
 - `id` (String) The ID of this resource.
-- `last_test_succeeded` (Boolean) Indicates if the last connection test to this destination was successful.
-- `last_tested_at` (String) Timestamp of when the last connection test was conducted on this destination.
 
 ## Import
 

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -43,7 +43,6 @@ resource "censusworkspace_source" "test" {
 ### Read-Only
 
 - `connection_details` (String) Detailed configuration and information for connecting to this source.
-- `created_at` (String) When the connection was created
 - `id` (String) The ID of this resource.
 - `label` (String, Deprecated) Deprecated. Use `name` for configuration. This read-only field reflects the API label when returned.
 - `last_test_succeeded` (Boolean) Indicates if the last connection test to this source was successful.

--- a/docs/resources/source.md
+++ b/docs/resources/source.md
@@ -45,8 +45,6 @@ resource "censusworkspace_source" "test" {
 - `connection_details` (String) Detailed configuration and information for connecting to this source.
 - `id` (String) The ID of this resource.
 - `label` (String, Deprecated) Deprecated. Use `name` for configuration. This read-only field reflects the API label when returned.
-- `last_test_succeeded` (Boolean) Indicates if the last connection test to this source was successful.
-- `last_tested_at` (String) Timestamp of when the last connection test was conducted on this source.
 
 ## Import
 

--- a/docs/resources/sql_dataset.md
+++ b/docs/resources/sql_dataset.md
@@ -27,8 +27,6 @@ description: |-
 
 ### Read-Only
 
-- `created_at` (String) Timestamp when the dataset was created.
 - `id` (String) The ID of this resource.
-- `updated_at` (String) Timestamp when the dataset was last updated.
 
 

--- a/internal/provider/big_query_destination_model_request.go
+++ b/internal/provider/big_query_destination_model_request.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package provider
 
 import (

--- a/internal/provider/big_query_destination_model_response.go
+++ b/internal/provider/big_query_destination_model_response.go
@@ -19,9 +19,8 @@ func NewBigQueryDestinationModelFromResponse(ctx context.Context, response cm.De
 
 	model := BigQueryDestinationModel{
 		destinationModelBase: destinationModelBase{
-			ID:        types.StringValue(strconv.FormatInt(response.ID, 10)),
-			Name:      types.StringValue(response.Name),
-			CreatedAt: timetypes.NewRFC3339TimeValue(response.CreatedAt),
+			ID:   types.StringValue(strconv.FormatInt(response.ID, 10)),
+			Name: types.StringValue(response.Name),
 		},
 	}
 

--- a/internal/provider/big_query_destination_model_response.go
+++ b/internal/provider/big_query_destination_model_response.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package provider
 
 import (
@@ -6,7 +5,6 @@ import (
 	"strconv"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -31,14 +29,6 @@ func NewBigQueryDestinationModelFromResponse(ctx context.Context, response cm.De
 		diags.Append(connectionDetailsDiags...)
 
 		model.ConnectionDetails = connectionDetails
-	}
-
-	if lastTestedAt, lastTestedAtOk := response.LastTestedAt.Get(); lastTestedAtOk {
-		model.LastTestedAt = timetypes.NewRFC3339TimeValue(lastTestedAt)
-	}
-
-	if lastTestSucceeded, lastTestSucceededOk := response.LastTestSucceeded.Get(); lastTestSucceededOk {
-		model.LastTestSucceeded = types.BoolValue(lastTestSucceeded)
 	}
 
 	return model, diags

--- a/internal/provider/big_query_destination_resource_test.go
+++ b/internal/provider/big_query_destination_resource_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	cmt "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go/testing"
@@ -87,20 +86,10 @@ func TestAccBigQueryDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectResourceAction("censusworkspace_big_query_destination.test", plancheck.ResourceActionCreate),
 						plancheck.ExpectUnknownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("id")),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
 			//nolint:dupl
 			{
-				PreConfig: func() {
-					destination := server.Handler().Destinations["1"]
-					if destination != nil {
-						destination.LastTestSucceeded.SetTo(false)
-						destination.LastTestedAt.SetTo(time.Unix(0, 0))
-					}
-				},
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: config.Variables{
 					"destination_type": config.StringVariable("big_query"),
@@ -117,9 +106,6 @@ func TestAccBigQueryDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("name"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Bool(false)),
 					},
 				},
 			},
@@ -175,7 +161,6 @@ func TestAccBigQueryDestinationResourceMovedFromDestination(t *testing.T) {
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},
@@ -193,9 +178,6 @@ func TestAccBigQueryDestinationResourceMovedFromDestination(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("credentials").AtMapKey("location"), knownvalue.StringExact("location")),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("credentials").AtMapKey("service_account_key"), knownvalue.Null()),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_big_query_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},

--- a/internal/provider/big_query_source_model_response.go
+++ b/internal/provider/big_query_source_model_response.go
@@ -18,10 +18,9 @@ func NewBigQuerySourceModelFromResponse(ctx context.Context, response cm.SourceD
 
 	model := BigQuerySourceModel{
 		sourceModelBase: sourceModelBase{
-			ID:        types.StringValue(strconv.FormatInt(response.ID, 10)),
-			Name:      types.StringValue(response.Name),
-			Label:     types.StringPointerValue(response.Label.ValueStringPointer()),
-			CreatedAt: timetypes.NewRFC3339TimeValue(response.CreatedAt),
+			ID:    types.StringValue(strconv.FormatInt(response.ID, 10)),
+			Name:  types.StringValue(response.Name),
+			Label: types.StringPointerValue(response.Label.ValueStringPointer()),
 		},
 	}
 

--- a/internal/provider/big_query_source_model_response.go
+++ b/internal/provider/big_query_source_model_response.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -39,14 +38,6 @@ func NewBigQuerySourceModelFromResponse(ctx context.Context, response cm.SourceD
 		diags.Append(connectionDetailsDiags...)
 
 		model.ConnectionDetails = connectionDetails
-	}
-
-	if lastTestedAt, lastTestedAtOk := response.LastTestedAt.Get(); lastTestedAtOk {
-		model.LastTestedAt = timetypes.NewRFC3339TimeValue(lastTestedAt)
-	}
-
-	if lastTestSucceeded, lastTestSucceededOk := response.LastTestSucceeded.Get(); lastTestSucceededOk {
-		model.LastTestSucceeded = types.BoolValue(lastTestSucceeded)
 	}
 
 	return model, diags

--- a/internal/provider/big_query_source_resource_test.go
+++ b/internal/provider/big_query_source_resource_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	cmt "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go/testing"
@@ -88,19 +87,9 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
 			{
-				PreConfig: func() {
-					source := server.Handler().Sources["1"]
-					if source != nil {
-						source.LastTestSucceeded.SetTo(false)
-						source.LastTestedAt.SetTo(time.Unix(0, 0))
-					}
-				},
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: config.Variables{
 					"source_name": config.StringVariable("Test Source"),
@@ -118,9 +107,6 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Bool(false)),
 					},
 				},
 			},
@@ -176,7 +162,7 @@ func TestAccBigQuerySourceResourceCreateUpdateDelete(t *testing.T) {
 	})
 }
 
-//nolint:dupl,paralleltest
+//nolint:paralleltest
 func TestAccBigQuerySourceResourceMovedFromSource(t *testing.T) {
 	server, err := cmt.NewCensusManagementServer()
 	require.NoError(t, err)
@@ -200,9 +186,6 @@ func TestAccBigQuerySourceResourceMovedFromSource(t *testing.T) {
 						plancheck.ExpectUnknownValue("censusworkspace_source.test", tfjsonpath.New("id")),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
 			{
@@ -219,9 +202,6 @@ func TestAccBigQuerySourceResourceMovedFromSource(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("credentials").AtMapKey("location"), knownvalue.StringExact("US")),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("credentials").AtMapKey("service_account_key"), knownvalue.Null()),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},
@@ -261,9 +241,6 @@ func TestAccBigQuerySourceResourceMovedFromSourceWithServiceAccountKey(t *testin
 						plancheck.ExpectUnknownValue("censusworkspace_source.test", tfjsonpath.New("id")),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
 			{
@@ -281,9 +258,6 @@ func TestAccBigQuerySourceResourceMovedFromSourceWithServiceAccountKey(t *testin
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("credentials").AtMapKey("service_account_key").AtMapKey("private_key_id"), knownvalue.StringExact("private-key-id")),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("credentials").AtMapKey("service_account_key").AtMapKey("client_email"), knownvalue.StringExact("client-email")),
 						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_big_query_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},

--- a/internal/provider/braze_destination_model_request.go
+++ b/internal/provider/braze_destination_model_request.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package provider
 
 import (

--- a/internal/provider/braze_destination_model_response.go
+++ b/internal/provider/braze_destination_model_response.go
@@ -19,9 +19,8 @@ func NewBrazeDestinationModelFromResponse(ctx context.Context, response cm.Desti
 
 	model := BrazeDestinationModel{
 		destinationModelBase: destinationModelBase{
-			ID:        types.StringValue(strconv.FormatInt(response.ID, 10)),
-			Name:      types.StringValue(response.Name),
-			CreatedAt: timetypes.NewRFC3339TimeValue(response.CreatedAt),
+			ID:   types.StringValue(strconv.FormatInt(response.ID, 10)),
+			Name: types.StringValue(response.Name),
 		},
 	}
 

--- a/internal/provider/braze_destination_model_response.go
+++ b/internal/provider/braze_destination_model_response.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package provider
 
 import (
@@ -6,7 +5,6 @@ import (
 	"strconv"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -31,14 +29,6 @@ func NewBrazeDestinationModelFromResponse(ctx context.Context, response cm.Desti
 		diags.Append(connectionDetailsDiags...)
 
 		model.ConnectionDetails = connectionDetails
-	}
-
-	if lastTestedAt, lastTestedAtOk := response.LastTestedAt.Get(); lastTestedAtOk {
-		model.LastTestedAt = timetypes.NewRFC3339TimeValue(lastTestedAt)
-	}
-
-	if lastTestSucceeded, lastTestSucceededOk := response.LastTestSucceeded.Get(); lastTestSucceededOk {
-		model.LastTestSucceeded = types.BoolValue(lastTestSucceeded)
 	}
 
 	return model, diags

--- a/internal/provider/braze_destination_resource_test.go
+++ b/internal/provider/braze_destination_resource_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	cmt "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go/testing"
@@ -87,20 +86,10 @@ func TestAccBrazeDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectResourceAction("censusworkspace_braze_destination.test", plancheck.ResourceActionCreate),
 						plancheck.ExpectUnknownValue("censusworkspace_braze_destination.test", tfjsonpath.New("id")),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
 			//nolint:dupl
 			{
-				PreConfig: func() {
-					destination := server.Handler().Destinations["1"]
-					if destination != nil {
-						destination.LastTestSucceeded.SetTo(false)
-						destination.LastTestedAt.SetTo(time.Unix(0, 0))
-					}
-				},
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: config.Variables{
 					"destination_type": config.StringVariable("braze"),
@@ -117,9 +106,6 @@ func TestAccBrazeDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("name"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Bool(false)),
 					},
 				},
 			},
@@ -174,7 +160,6 @@ func TestAccBrazeDestinationResourceMovedFromDestination(t *testing.T) {
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},
@@ -191,9 +176,6 @@ func TestAccBrazeDestinationResourceMovedFromDestination(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("credentials").AtMapKey("instance_url"), knownvalue.StringExact("instance-url")),
 						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("credentials").AtMapKey("api_key"), knownvalue.StringExact("api-key")),
 						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_braze_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},

--- a/internal/provider/custom_api_destination_model_response.go
+++ b/internal/provider/custom_api_destination_model_response.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package provider
 
 import (
@@ -6,7 +5,6 @@ import (
 	"strconv"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -31,14 +29,6 @@ func NewCustomAPIDestinationModelFromResponse(ctx context.Context, response cm.D
 		diags.Append(connectionDetailsDiags...)
 
 		model.ConnectionDetails = connectionDetails
-	}
-
-	if lastTestedAt, lastTestedAtOk := response.LastTestedAt.Get(); lastTestedAtOk {
-		model.LastTestedAt = timetypes.NewRFC3339TimeValue(lastTestedAt)
-	}
-
-	if lastTestSucceeded, lastTestSucceededOk := response.LastTestSucceeded.Get(); lastTestSucceededOk {
-		model.LastTestSucceeded = types.BoolValue(lastTestSucceeded)
 	}
 
 	return model, diags

--- a/internal/provider/custom_api_destination_model_response.go
+++ b/internal/provider/custom_api_destination_model_response.go
@@ -19,9 +19,8 @@ func NewCustomAPIDestinationModelFromResponse(ctx context.Context, response cm.D
 
 	model := CustomAPIDestinationModel{
 		destinationModelBase: destinationModelBase{
-			ID:        types.StringValue(strconv.FormatInt(response.ID, 10)),
-			Name:      types.StringValue(response.Name),
-			CreatedAt: timetypes.NewRFC3339TimeValue(response.CreatedAt),
+			ID:   types.StringValue(strconv.FormatInt(response.ID, 10)),
+			Name: types.StringValue(response.Name),
 		},
 	}
 

--- a/internal/provider/custom_api_destination_resource_test.go
+++ b/internal/provider/custom_api_destination_resource_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	cmt "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go/testing"
@@ -87,20 +86,9 @@ func TestAccCustomAPIDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectResourceAction("censusworkspace_custom_api_destination.test", plancheck.ResourceActionCreate),
 						plancheck.ExpectUnknownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("id")),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
-			//nolint:dupl
 			{
-				PreConfig: func() {
-					destination := server.Handler().Destinations["1"]
-					if destination != nil {
-						destination.LastTestSucceeded.SetTo(false)
-						destination.LastTestedAt.SetTo(time.Unix(0, 0))
-					}
-				},
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: config.Variables{
 					"destination_type": config.StringVariable("custom_api"),
@@ -117,9 +105,6 @@ func TestAccCustomAPIDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("name"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Bool(false)),
 					},
 				},
 			},
@@ -182,7 +167,6 @@ func TestAccCustomAPIDestinationResourceMovedFromDestination(t *testing.T) {
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},
@@ -200,9 +184,6 @@ func TestAccCustomAPIDestinationResourceMovedFromDestination(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("webhook_url"), knownvalue.StringExact("https://example.org/census-destination")),
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers"), knownvalue.Null()),
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},
@@ -244,7 +225,6 @@ func TestAccCustomAPIDestinationResourceMovedFromDestinationWithCustomHeaders(t 
 					},
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},
@@ -262,9 +242,6 @@ func TestAccCustomAPIDestinationResourceMovedFromDestinationWithCustomHeaders(t 
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("webhook_url"), knownvalue.StringExact("https://example.org/census-destination")),
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("credentials").AtMapKey("custom_headers"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_custom_api_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},

--- a/internal/provider/destination_base.go
+++ b/internal/provider/destination_base.go
@@ -13,7 +13,6 @@ import (
 type destinationModelBase struct {
 	ID                types.String      `tfsdk:"id"`
 	Name              types.String      `tfsdk:"name"`
-	CreatedAt         timetypes.RFC3339 `tfsdk:"created_at"`
 	LastTestedAt      timetypes.RFC3339 `tfsdk:"last_tested_at"`
 	LastTestSucceeded types.Bool        `tfsdk:"last_test_succeeded"`
 }
@@ -29,11 +28,6 @@ func destinationBaseResourceSchemaAttributes(_ context.Context) map[string]schem
 		"name": schema.StringAttribute{
 			Required:            true,
 			MarkdownDescription: "The name of this destination.",
-		},
-		"created_at": schema.StringAttribute{
-			CustomType:          timetypes.RFC3339Type{},
-			Computed:            true,
-			MarkdownDescription: "When the connection was created",
 		},
 		"last_tested_at": schema.StringAttribute{
 			CustomType:          timetypes.RFC3339Type{},

--- a/internal/provider/destination_base.go
+++ b/internal/provider/destination_base.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -11,10 +10,8 @@ import (
 )
 
 type destinationModelBase struct {
-	ID                types.String      `tfsdk:"id"`
-	Name              types.String      `tfsdk:"name"`
-	LastTestedAt      timetypes.RFC3339 `tfsdk:"last_tested_at"`
-	LastTestSucceeded types.Bool        `tfsdk:"last_test_succeeded"`
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
 }
 
 func destinationBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
@@ -28,15 +25,6 @@ func destinationBaseResourceSchemaAttributes(_ context.Context) map[string]schem
 		"name": schema.StringAttribute{
 			Required:            true,
 			MarkdownDescription: "The name of this destination.",
-		},
-		"last_tested_at": schema.StringAttribute{
-			CustomType:          timetypes.RFC3339Type{},
-			Computed:            true,
-			MarkdownDescription: "Timestamp of when the last connection test was conducted on this destination.",
-		},
-		"last_test_succeeded": schema.BoolAttribute{
-			Computed:            true,
-			MarkdownDescription: "Indicates if the last connection test to this destination was successful.",
 		},
 	}
 }

--- a/internal/provider/destination_model_response.go
+++ b/internal/provider/destination_model_response.go
@@ -14,9 +14,8 @@ import (
 func NewDestinationModelFromResponse(_ context.Context, response cm.DestinationData) (DestinationModel, diag.Diagnostics) {
 	model := DestinationModel{
 		destinationModelBase: destinationModelBase{
-			ID:        types.StringValue(strconv.FormatInt(response.ID, 10)),
-			Name:      types.StringValue(response.Name),
-			CreatedAt: timetypes.NewRFC3339TimeValue(response.CreatedAt),
+			ID:   types.StringValue(strconv.FormatInt(response.ID, 10)),
+			Name: types.StringValue(response.Name),
 		},
 		Type: types.StringValue(response.Type),
 	}

--- a/internal/provider/destination_model_response.go
+++ b/internal/provider/destination_model_response.go
@@ -6,7 +6,6 @@ import (
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -22,14 +21,6 @@ func NewDestinationModelFromResponse(_ context.Context, response cm.DestinationD
 
 	if response.ConnectionDetails != nil {
 		model.ConnectionDetails = jsontypes.NewNormalizedValue(string(response.ConnectionDetails))
-	}
-
-	if lastTestedAt, lastTestedAtOk := response.LastTestedAt.Get(); lastTestedAtOk {
-		model.LastTestedAt = timetypes.NewRFC3339TimeValue(lastTestedAt)
-	}
-
-	if lastTestSucceeded, lastTestSucceededOk := response.LastTestSucceeded.Get(); lastTestSucceededOk {
-		model.LastTestSucceeded = types.BoolValue(lastTestSucceeded)
 	}
 
 	return model, nil

--- a/internal/provider/destination_resource_test.go
+++ b/internal/provider/destination_resource_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	cmt "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go/testing"
@@ -86,19 +85,9 @@ func TestAccDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectResourceAction("censusworkspace_destination.test", plancheck.ResourceActionCreate),
 						plancheck.ExpectUnknownValue("censusworkspace_destination.test", tfjsonpath.New("id")),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
 			{
-				PreConfig: func() {
-					destination := server.Handler().Destinations["1"]
-					if destination != nil {
-						destination.LastTestSucceeded.SetTo(false)
-						destination.LastTestedAt.SetTo(time.Unix(0, 0))
-					}
-				},
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: config.Variables{
 					"destination_type": config.StringVariable("custom_api"),
@@ -114,9 +103,6 @@ func TestAccDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("id"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("name"), knownvalue.NotNull()),
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Bool(false)),
 					},
 				},
 			},
@@ -153,9 +139,6 @@ func TestAccDestinationResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectUnknownValue("censusworkspace_destination.test", tfjsonpath.New("id")),
 						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Destination (replaced)")),
 						plancheck.ExpectUnknownValue("censusworkspace_destination.test", tfjsonpath.New("connection_details")),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_destination.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},

--- a/internal/provider/source_base.go
+++ b/internal/provider/source_base.go
@@ -19,7 +19,6 @@ type sourceModelBase struct {
 	Label                             types.String      `tfsdk:"label"`
 	SyncEngine                        types.String      `tfsdk:"sync_engine"`
 	WarehouseWritebackRetentionInDays types.Int64       `tfsdk:"warehouse_writeback_retention_in_days"`
-	CreatedAt                         timetypes.RFC3339 `tfsdk:"created_at"`
 	LastTestedAt                      timetypes.RFC3339 `tfsdk:"last_tested_at"`
 	LastTestSucceeded                 types.Bool        `tfsdk:"last_test_succeeded"`
 }
@@ -60,11 +59,6 @@ func sourceBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Att
 				int64planmodifier.UseStateForUnknown(),
 			},
 			MarkdownDescription: "Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.",
-		},
-		"created_at": schema.StringAttribute{
-			CustomType:          timetypes.RFC3339Type{},
-			Computed:            true,
-			MarkdownDescription: "When the connection was created",
 		},
 		"last_tested_at": schema.StringAttribute{
 			CustomType:          timetypes.RFC3339Type{},

--- a/internal/provider/source_base.go
+++ b/internal/provider/source_base.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -14,13 +13,11 @@ import (
 )
 
 type sourceModelBase struct {
-	ID                                types.String      `tfsdk:"id"`
-	Name                              types.String      `tfsdk:"name"`
-	Label                             types.String      `tfsdk:"label"`
-	SyncEngine                        types.String      `tfsdk:"sync_engine"`
-	WarehouseWritebackRetentionInDays types.Int64       `tfsdk:"warehouse_writeback_retention_in_days"`
-	LastTestedAt                      timetypes.RFC3339 `tfsdk:"last_tested_at"`
-	LastTestSucceeded                 types.Bool        `tfsdk:"last_test_succeeded"`
+	ID                                types.String `tfsdk:"id"`
+	Name                              types.String `tfsdk:"name"`
+	Label                             types.String `tfsdk:"label"`
+	SyncEngine                        types.String `tfsdk:"sync_engine"`
+	WarehouseWritebackRetentionInDays types.Int64  `tfsdk:"warehouse_writeback_retention_in_days"`
 }
 
 func sourceBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Attribute {
@@ -59,15 +56,6 @@ func sourceBaseResourceSchemaAttributes(_ context.Context) map[string]schema.Att
 				int64planmodifier.UseStateForUnknown(),
 			},
 			MarkdownDescription: "Number of days to retain warehouse writeback data. When set, automatically enables sync logs for this source.",
-		},
-		"last_tested_at": schema.StringAttribute{
-			CustomType:          timetypes.RFC3339Type{},
-			Computed:            true,
-			MarkdownDescription: "Timestamp of when the last connection test was conducted on this source.",
-		},
-		"last_test_succeeded": schema.BoolAttribute{
-			Computed:            true,
-			MarkdownDescription: "Indicates if the last connection test to this source was successful.",
 		},
 	}
 }

--- a/internal/provider/source_model_response.go
+++ b/internal/provider/source_model_response.go
@@ -14,10 +14,9 @@ import (
 func NewSourceModelFromResponse(_ context.Context, response cm.SourceData) (SourceModel, diag.Diagnostics) {
 	model := SourceModel{
 		sourceModelBase: sourceModelBase{
-			ID:        types.StringValue(strconv.FormatInt(response.ID, 10)),
-			Name:      types.StringValue(response.Name),
-			Label:     types.StringPointerValue(response.Label.ValueStringPointer()),
-			CreatedAt: timetypes.NewRFC3339TimeValue(response.CreatedAt),
+			ID:    types.StringValue(strconv.FormatInt(response.ID, 10)),
+			Name:  types.StringValue(response.Name),
+			Label: types.StringPointerValue(response.Label.ValueStringPointer()),
 		},
 		Type: types.StringValue(response.Type),
 	}

--- a/internal/provider/source_model_response.go
+++ b/internal/provider/source_model_response.go
@@ -6,7 +6,6 @@ import (
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -31,14 +30,6 @@ func NewSourceModelFromResponse(_ context.Context, response cm.SourceData) (Sour
 
 	if response.ConnectionDetails != nil {
 		model.ConnectionDetails = jsontypes.NewNormalizedValue(string(response.ConnectionDetails))
-	}
-
-	if lastTestedAt, lastTestedAtOk := response.LastTestedAt.Get(); lastTestedAtOk {
-		model.LastTestedAt = timetypes.NewRFC3339TimeValue(lastTestedAt)
-	}
-
-	if lastTestSucceeded, lastTestSucceededOk := response.LastTestSucceeded.Get(); lastTestSucceededOk {
-		model.LastTestSucceeded = types.BoolValue(lastTestSucceeded)
 	}
 
 	return model, nil

--- a/internal/provider/source_resource_test.go
+++ b/internal/provider/source_resource_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
 	cmt "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go/testing"
@@ -92,19 +91,9 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
-					},
 				},
 			},
 			{
-				PreConfig: func() {
-					source := server.Handler().Sources["1"]
-					if source != nil {
-						source.LastTestSucceeded.SetTo(false)
-						source.LastTestedAt.SetTo(time.Unix(0, 0))
-					}
-				},
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: config.Variables{
 					"source_type": config.StringVariable("big_query"),
@@ -123,9 +112,6 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source")),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("warehouse_writeback_retention_in_days"), knownvalue.Int64Exact(7)),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("connection_details"), knownvalue.NotNull()),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Bool(false)),
 					},
 				},
 			},
@@ -187,9 +173,6 @@ func TestAccSourceResourceCreateUpdateDelete(t *testing.T) {
 						plancheck.ExpectUnknownValue("censusworkspace_source.test", tfjsonpath.New("id")),
 						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("name"), knownvalue.StringExact("Test Source (replaced)")),
 						plancheck.ExpectUnknownValue("censusworkspace_source.test", tfjsonpath.New("connection_details")),
-					},
-					PostApplyPostRefresh: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue("censusworkspace_source.test", tfjsonpath.New("last_test_succeeded"), knownvalue.Null()),
 					},
 				},
 			},
@@ -272,11 +255,9 @@ func TestAccSourceResourceSyncEngineAppearing(t *testing.T) {
 //nolint:paralleltest
 func TestProtocol6SourceResourceReadAcceptsExistingLabelState(t *testing.T) {
 	testProtocol6SourceResourceReadAcceptsExistingLabelState(t, "censusworkspace_source", map[string]tftypes.Value{
-		"type":                tftypes.NewValue(tftypes.String, "big_query"),
-		"credentials":         tftypes.NewValue(tftypes.String, `{"project_id":"project-id","location":"US"}`),
-		"connection_details":  tftypes.NewValue(tftypes.String, nil),
-		"last_tested_at":      tftypes.NewValue(tftypes.String, nil),
-		"last_test_succeeded": tftypes.NewValue(tftypes.Bool, nil),
+		"type":               tftypes.NewValue(tftypes.String, "big_query"),
+		"credentials":        tftypes.NewValue(tftypes.String, `{"project_id":"project-id","location":"US"}`),
+		"connection_details": tftypes.NewValue(tftypes.String, nil),
 	})
 }
 
@@ -306,8 +287,6 @@ func TestProtocol6BigQuerySourceResourceReadAcceptsExistingLabelState(t *testing
 			"location":        tftypes.String,
 			"service_account": tftypes.String,
 		}}, nil),
-		"last_tested_at":      tftypes.NewValue(tftypes.String, nil),
-		"last_test_succeeded": tftypes.NewValue(tftypes.Bool, nil),
 	})
 }
 

--- a/internal/provider/source_resource_test.go
+++ b/internal/provider/source_resource_test.go
@@ -359,7 +359,6 @@ func testProtocol6SourceResourceReadAcceptsExistingLabelState(
 	resourceState["label"] = tftypes.NewValue(tftypes.String, "Legacy Label")
 	resourceState["sync_engine"] = tftypes.NewValue(tftypes.String, nil)
 	resourceState["warehouse_writeback_retention_in_days"] = tftypes.NewValue(tftypes.Number, nil)
-	resourceState["created_at"] = tftypes.NewValue(tftypes.String, nil)
 
 	currentState, err := tfprotov6.NewDynamicValue(sourceType, tftypes.NewValue(sourceType, resourceState))
 	require.NoError(t, err)

--- a/internal/provider/sql_dataset_model.go
+++ b/internal/provider/sql_dataset_model.go
@@ -1,16 +1,11 @@
 package provider
 
-import (
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-)
+import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type SQLDatasetModel struct {
-	ID          types.String      `tfsdk:"id"`
-	Name        types.String      `tfsdk:"name"`
-	SourceID    types.Int64       `tfsdk:"source_id"`
-	Query       types.String      `tfsdk:"query"`
-	Description types.String      `tfsdk:"description"`
-	CreatedAt   timetypes.RFC3339 `tfsdk:"created_at"`
-	UpdatedAt   timetypes.RFC3339 `tfsdk:"updated_at"`
+	ID          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	SourceID    types.Int64  `tfsdk:"source_id"`
+	Query       types.String `tfsdk:"query"`
+	Description types.String `tfsdk:"description"`
 }

--- a/internal/provider/sql_dataset_model_response.go
+++ b/internal/provider/sql_dataset_model_response.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	cm "github.com/cysp/terraform-provider-censusworkspace/internal/census-management-go"
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -33,9 +32,6 @@ func NewSQLDatasetModelFromResponse(_ context.Context, path path.Path, data cm.D
 	if description != "" {
 		model.Description = types.StringValue(description)
 	}
-
-	model.CreatedAt = timetypes.NewRFC3339TimeValue(sql.CreatedAt)
-	model.UpdatedAt = timetypes.NewRFC3339TimeValue(sql.UpdatedAt)
 
 	return model, diags
 }

--- a/internal/provider/sql_dataset_resource_schema.go
+++ b/internal/provider/sql_dataset_resource_schema.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -49,16 +48,6 @@ func SQLDatasetResourceSchema(_ context.Context) schema.Schema {
 			"description": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "Description of the dataset.",
-			},
-			"created_at": schema.StringAttribute{
-				CustomType:          timetypes.RFC3339Type{},
-				Computed:            true,
-				MarkdownDescription: "Timestamp when the dataset was created.",
-			},
-			"updated_at": schema.StringAttribute{
-				CustomType:          timetypes.RFC3339Type{},
-				Computed:            true,
-				MarkdownDescription: "Timestamp when the dataset was last updated.",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- remove created_at and updated_at from managed resource schemas and docs
- remove source/destination connection test status fields from managed resource schemas and docs
- update response mapping and acceptance tests for the narrower resource state

## Tests
- go test ./internal/provider